### PR TITLE
Add chartmuseumtest package

### DIFF
--- a/pkg/chartmuseumtest/chartmuseumfake.go
+++ b/pkg/chartmuseumtest/chartmuseumfake.go
@@ -1,0 +1,184 @@
+package chartmuseumtest
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"path"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v2"
+)
+
+// A tChartMuseumFake is a fake ChartMuseum implementation useful for (fast)
+// unit tests.
+//
+// An instance implements `http.Handler` so can be used directly or with
+// `httptest.NewServer` to make it available over HTTP.
+type tChartMuseumFake struct {
+	t *testing.T
+
+	// Expected basic auth credentials.
+	username string
+	password string
+
+	// Set to simulate HTTP error responses for specific API calls.
+	ChartsPostError *httpError
+
+	// Map of chart name to indexed versions, as returned by the charts API.
+	index map[string][]*ChartVersion
+}
+
+// Metadata in Chart.yaml files
+type Metadata struct {
+	AppVersion string `json:"appVersion"`
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+}
+
+type ChartVersion struct {
+	Name    string   `json:"name"`
+	Version string   `json:"version"`
+	URLs    []string `json:"urls"`
+}
+
+type httpError struct {
+	status int
+	body   string
+}
+
+func newChartMuseumFake(t *testing.T, username, password string) *tChartMuseumFake {
+	return &tChartMuseumFake{
+		t:        t,
+		username: username,
+		password: password,
+		index:    make(map[string][]*ChartVersion),
+	}
+}
+
+func (cm *tChartMuseumFake) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Check basic auth credentals.
+	username, password, ok := r.BasicAuth()
+	if got, want := ok, true; got != want {
+		cm.t.Errorf("got: %t, want: %t", got, want)
+	}
+	if got, want := username, cm.username; got != want {
+		cm.t.Errorf("got: %q, want: %q", got, want)
+	}
+	if got, want := password, cm.password; got != want {
+		cm.t.Errorf("got: %q, want: %q", got, want)
+	}
+
+	// Handle recognized requests.
+	if base, chart := path.Split(r.URL.Path); base == "/api/charts/" && r.Method == "GET" {
+		cm.chartGet(w, r, chart)
+		return
+	}
+	if r.URL.Path == "/api/charts" && r.Method == "POST" {
+		cm.chartsPost(w, r)
+		return
+	}
+	if r.URL.Path == "/index.yaml" && r.Method == "GET" {
+		cm.indexGet(w, r)
+		return
+	}
+	re := regexp.MustCompile(`(?m)\/charts\/(.*.tgz)`)
+	if re.Match([]byte(r.URL.Path)) && r.Method == "GET" {
+		chartPackage := strings.Split(r.URL.Path, "/")[2]
+		cm.chartPackageGet(w, r, chartPackage)
+		return
+	}
+
+	cm.t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+}
+
+func (cm *tChartMuseumFake) chartGet(w http.ResponseWriter, r *http.Request, chart string) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(cm.index[chart]); err != nil {
+		cm.t.Fatal(err)
+	}
+}
+func (cm *tChartMuseumFake) indexGet(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(cm.index); err != nil {
+		cm.t.Fatal(err)
+	}
+}
+
+func (cm *tChartMuseumFake) chartPackageGet(w http.ResponseWriter, r *http.Request, chartPackageName string) {
+	w.WriteHeader(200)
+	// Get chart from testdata folder
+	chartPackageFile := path.Join("../../testdata", chartPackageName)
+	chartPackage, err := ioutil.ReadFile(chartPackageFile)
+	if err != nil {
+		cm.t.Fatal(err)
+	}
+	w.Write(chartPackage)
+}
+
+func (cm *tChartMuseumFake) chartsPost(w http.ResponseWriter, r *http.Request) {
+	if cm.ChartsPostError != nil {
+		w.WriteHeader(cm.ChartsPostError.status)
+		w.Write([]byte(cm.ChartsPostError.body))
+		return
+	}
+
+	chartFile, _, err := r.FormFile("chart")
+	if err != nil {
+		cm.t.Fatal(err)
+	}
+
+	metadata, err := chartMetadataFromTGZ(chartFile)
+	if err != nil {
+		cm.t.Fatal(err)
+	}
+
+	cm.index[metadata.Name] = append(cm.index[metadata.Name], &ChartVersion{
+		Name:    metadata.Name,
+		Version: metadata.Version,
+		URLs:    []string{fmt.Sprintf("charts/%s-%s.tgz", metadata.Name, metadata.Version)},
+	})
+
+	w.WriteHeader(201)
+	w.Write([]byte(`{}`))
+}
+
+func chartMetadataFromTGZ(r io.Reader) (*Metadata, error) {
+	const (
+		metadataFile = "Chart.yaml"
+	)
+
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	t := tar.NewReader(gz)
+
+	// Iterate over tar until the metadata file
+	for {
+		h, err := t.Next()
+		if err != nil {
+			return nil, err
+		}
+		// A tgz may contain multiple Chart.yaml files - the main chart and its
+		// subcharts - but assume there are no subcharts for now.
+		_, file := filepath.Split(h.Name)
+		if file == metadataFile {
+			break
+		}
+	}
+
+	data, err := ioutil.ReadAll(t)
+	if err != nil {
+		return nil, err
+	}
+	m := &Metadata{}
+	return m, yaml.Unmarshal(data, m)
+}

--- a/pkg/chartmuseumtest/chartmuseumreal.go
+++ b/pkg/chartmuseumtest/chartmuseumreal.go
@@ -1,0 +1,83 @@
+package chartmuseumtest
+
+import (
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// tChartMuseumReal starts a real ChartMuseum service on an available port,
+// running in a Docker container. Most tests should use a fake instead.
+//
+// The URL of the service and a cleanup func that should be called once the
+// service is no longer needed are returned.
+//
+// Any errors while setting up or tearing down the service will be reported on
+// the *testing.T instance.
+//
+// Since pulling an image and running a service is time consuming, any tests
+// using this are skipped for `-test.short` runs. The test is also skipped if no
+// `docker` binary can be located.
+func tChartMuseumReal(t *testing.T, username, password string) (string, func()) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode")
+	}
+
+	// Start chartmuseum in Docker publishing the default port to an available
+	// host port.
+	// Charts are stored in "local" storage backed by a Docker volume so they
+	// can be deleted easily. The image runs as user 1000:1000 by default but is
+	// overridden back to 0:0 here to avoid setting up volume permissions.
+	chartsVolume := tDockerVolumeCreate(t)
+	id := tDockerRunDetach(t,
+		"--publish", "0:8080",
+		"--volume", fmt.Sprintf("%s:/charts", chartsVolume),
+		"--user", "0:0",
+		"chartmuseum/chartmuseum",
+		"--depth-dynamic", // Arbitrary multitenancy repo depth
+		"--storage", "local", "--storage-local-rootdir", "/charts",
+		"--basic-auth-user", username, "--basic-auth-pass", password,
+	)
+	port := strings.TrimSpace(tDockerExec(t,
+		"inspect", "--format", `{{(index (index .NetworkSettings.Ports "8080/tcp") 0).HostPort}}`,
+		id,
+	))
+
+	return "http://localhost:" + port, func() {
+		tDockerExec(t, "stop", id)
+		tDockerExec(t, "rm", id)
+		tDockerVolumeRm(t, chartsVolume)
+	}
+}
+
+func tDockerVolumeCreate(t *testing.T) string {
+	return strings.TrimSpace(tDockerExec(t, "volume", "create"))
+}
+
+func tDockerVolumeRm(t *testing.T, volume string) string {
+	return strings.TrimSpace(tDockerExec(t, "volume", "rm", volume))
+}
+
+func tDockerRunDetach(t *testing.T, args ...string) string {
+	args = append([]string{"run", "-d"}, args...)
+	return strings.TrimSpace(tDockerExec(t, args...))
+}
+
+func tDockerExec(t *testing.T, args ...string) string {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skipf("skipping test, `docker` not found: %s", err)
+	}
+
+	cmd := exec.Command("docker", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) {
+			err = fmt.Errorf("%s: %w", exitError.Stderr, err)
+		}
+		t.Fatal(err)
+	}
+	return string(out)
+}

--- a/pkg/chartmuseumtest/common.go
+++ b/pkg/chartmuseumtest/common.go
@@ -1,0 +1,44 @@
+package chartmuseumtest
+
+import (
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+var (
+	username string = "user"
+	password string = "password"
+
+	// Execute the test twice, against real & fake ChartMuseum services. This
+	// validates the publisher is correct and, at the same time, provides
+	// reasonable confidence the fake implementation is good enough.
+	Tests = []struct {
+		Desc       string
+		Skip       func(t *testing.T)
+		MakeServer func(t *testing.T) (string, func())
+	}{
+		{
+			"real service",
+			func(t *testing.T) {
+				key := "TEST_WITH_REAL_CHARTMUSEUM"
+				if os.Getenv(key) == "" {
+					t.Skipf("skipping because %s env var not set", key)
+				}
+			},
+			func(t *testing.T) (string, func()) {
+				return tChartMuseumReal(t, username, password)
+			},
+		},
+		{
+			"fake service",
+			func(t *testing.T) {},
+			func(t *testing.T) (string, func()) {
+				s := httptest.NewServer(newChartMuseumFake(t, username, password))
+				return s.URL, func() {
+					s.Close()
+				}
+			},
+		},
+	}
+)


### PR DESCRIPTION
This PR adds the `chartmuseumtest` package. A package that contains shared functions to be used by other packages test files.

