### PR TITLE
not capitalize errors and use t.Fatalf if test preparation step fail

### DIFF
--- a/api/config_test.go
+++ b/api/config_test.go
@@ -35,6 +35,6 @@ func TestValidate(t *testing.T) {
 	expectedError := `"source.repo.url" should be a valid URL: parse "ht//:fake.source.com": invalid URI for request`
 	err := config.Validate()
 	if err != nil && err.Error() != expectedError {
-		t.Errorf("Incorrect error, got: \n %s \n, want: \n %s \n", err.Error(), expectedError)
+		t.Errorf("incorrect error, got: \n %s \n, want: \n %s \n", err.Error(), expectedError)
 	}
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -58,7 +58,7 @@ func sync() error {
 	// Load index.yaml info into index object
 	sourceIndex, err := utils.LoadIndexFromRepo(source.Repo)
 	if err != nil {
-		return errors.Trace(fmt.Errorf("Error loading index.yaml: %w", err))
+		return errors.Trace(fmt.Errorf("error loading index.yaml: %w", err))
 	}
 	// Add target repo to helm CLI
 	helmcli.AddRepoToHelm(target.Repo.Url, target.Repo.Auth)

--- a/cmd/sync_chart.go
+++ b/cmd/sync_chart.go
@@ -48,7 +48,7 @@ func newSyncChart() *cobra.Command {
 
 func syncChart() error {
 	if !syncAllVersions && version == "" {
-		return errors.Trace(fmt.Errorf("Please specify a version to sync with --version VERSION or sync all versions with --all-versions"))
+		return errors.Trace(fmt.Errorf("please specify a version to sync with --version VERSION or sync all versions with --all-versions"))
 	}
 
 	// Load config file
@@ -65,7 +65,7 @@ func syncChart() error {
 	// Load index.yaml info into index object
 	sourceIndex, err := utils.LoadIndexFromRepo(source.Repo)
 	if err != nil {
-		return errors.Trace(fmt.Errorf("Error loading index.yaml: %w", err))
+		return errors.Trace(fmt.Errorf("error loading index.yaml: %w", err))
 	}
 
 	// Add target repo to helm CLI
@@ -86,14 +86,14 @@ func syncChart() error {
 			return errors.Trace(err)
 		}
 		if !srcExists {
-			return errors.Errorf("Chart %s-%s not found in source index.yaml", name, version)
+			return errors.Errorf("chart %s-%s not found in source index.yaml", name, version)
 		}
 		targetExists, err := tc.ChartExists(name, version, target.Repo)
 		if err != nil {
 			return errors.Trace(err)
 		}
 		if targetExists {
-			klog.Infof("Chart %s-%s already exists in target repo", name, version)
+			klog.Infof("chart %s-%s already exists in target repo", name, version)
 			return nil
 		}
 		if dryRun {

--- a/cmd/sync_chart.go
+++ b/cmd/sync_chart.go
@@ -31,6 +31,15 @@ func newSyncChart() *cobra.Command {
 
 	Example:
 	$ charts-syncer syncChart --name nginx --version 1.0.0 --config .charts-syncer.yaml`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if !syncAllVersions && version == "" {
+				return errors.Trace(fmt.Errorf(`missing "--version" flag: Please use either "--version VERSION" or "--all-versions"`))
+			}
+			if syncAllVersions && version != "" {
+				klog.Warningf(`Ignoring "--version" flag: "--all-versions" is set`)
+			}
+			return nil
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return errors.Trace(syncChart())
 		},
@@ -47,10 +56,6 @@ func newSyncChart() *cobra.Command {
 }
 
 func syncChart() error {
-	if !syncAllVersions && version == "" {
-		return errors.Trace(fmt.Errorf("please specify a version to sync with --version VERSION or sync all versions with --all-versions"))
-	}
-
 	// Load config file
 	var syncConfig api.Config
 	if err := config.Load(&syncConfig); err != nil {

--- a/pkg/chart/chart_test.go
+++ b/pkg/chart/chart_test.go
@@ -36,7 +36,7 @@ func TestDownload(t *testing.T) {
 	// Create temporary working directory
 	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 	if err != nil {
-		t.Errorf("Error creating temporary: %s", testTmpDir)
+		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 	chartPath := path.Join(testTmpDir, "nginx-5.3.1.tgz")
@@ -47,13 +47,13 @@ func TestDownload(t *testing.T) {
 	}
 	sourceIndex, err := utils.LoadIndexFromRepo(source.Repo)
 	if err != nil {
-		t.Errorf("Error loading index.yaml: %w", err)
+		t.Fatalf("error loading index.yaml: %v", err)
 	}
 	if err := sc.DownloadChart(chartPath, "nginx", "5.3.1", source.Repo, sourceIndex); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(chartPath); err != nil {
-		t.Errorf("Chart package does not exist")
+		t.Errorf("chart package does not exist")
 	}
 }
 
@@ -91,7 +91,7 @@ volumePermissions:
 	// Create temporary working directory
 	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 	if err != nil {
-		t.Errorf("Error creating temporary: %s", testTmpDir)
+		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 	destValuesFilePath := path.Join(testTmpDir, "values.yaml")
@@ -99,7 +99,7 @@ volumePermissions:
 	// Write file
 	err = ioutil.WriteFile(destValuesFilePath, []byte(originalValues), 0644)
 	if err != nil {
-		t.Errorf("Error writting destination file")
+		t.Fatalf("error writting destination file")
 	}
 
 	updateValuesFile(destValuesFilePath, target)
@@ -109,7 +109,7 @@ volumePermissions:
 	}
 	got := string(valuesFile)
 	if want != got {
-		t.Errorf("Incorrect modification, got: \n %s \n, want: \n %s \n", got, want)
+		t.Errorf("incorrect modification, got: \n %s \n, want: \n %s \n", got, want)
 	}
 }
 
@@ -137,7 +137,7 @@ The above parameters map to the env variables defined in [bitnami/ghost](http://
 	// Create temporary working directory
 	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 	if err != nil {
-		t.Errorf("Error creating temporary: %s", testTmpDir)
+		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 	destValuesFilePath := path.Join(testTmpDir, "README.md")
@@ -145,7 +145,7 @@ The above parameters map to the env variables defined in [bitnami/ghost](http://
 	// Write file
 	err = ioutil.WriteFile(destValuesFilePath, []byte(originalValues), 0644)
 	if err != nil {
-		t.Errorf("Error writting destination file")
+		t.Fatalf("error writting destination file")
 	}
 
 	updateReadmeFile(destValuesFilePath, "https://charts.bitnami.com/bitnami", "https://my-new-chart-repo.com", "ghost", "mytestrepo")
@@ -155,6 +155,6 @@ The above parameters map to the env variables defined in [bitnami/ghost](http://
 	}
 	got := string(readmeFile)
 	if want != got {
-		t.Errorf("Incorrect modification, got: \n %s \n, want: \n %s \n", got, want)
+		t.Errorf("incorrect modification, got: \n %s \n, want: \n %s \n", got, want)
 	}
 }

--- a/pkg/chart/dependency.go
+++ b/pkg/chart/dependency.go
@@ -59,7 +59,7 @@ func syncDependencies(chartPath string, sourceRepo *api.Repo, target *api.Target
 		}
 		if !syncDeps {
 			missingDependencies = true
-			errs = multierror.Append(errs, errors.Errorf("Please sync %s-%s dependency first", depName, depVersion))
+			errs = multierror.Append(errs, errors.Errorf("please sync %s-%s dependency first", depName, depVersion))
 			continue
 		}
 		klog.Infof("Dependency %s-%s not synced yet. Syncing now", depName, depVersion)
@@ -71,7 +71,7 @@ func syncDependencies(chartPath string, sourceRepo *api.Repo, target *api.Target
 			return errors.Trace(err)
 		}
 		if !chartExists {
-			return errors.Errorf("Dependency %s-%s not available yet", depName, depVersion)
+			return errors.Errorf("dependency %s-%s not available yet", depName, depVersion)
 		}
 		klog.Infof("Dependency %s-%s synced", depName, depVersion)
 	}

--- a/pkg/chart/dependency_test.go
+++ b/pkg/chart/dependency_test.go
@@ -16,7 +16,7 @@ import (
 func TestSyncDependencies(t *testing.T) {
 	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 	if err != nil {
-		t.Errorf("Error creating temporary: %s", testTmpDir)
+		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 
@@ -27,14 +27,14 @@ func TestSyncDependencies(t *testing.T) {
 
 	sourceIndex, err := utils.LoadIndexFromRepo(source.Repo)
 	if err != nil {
-		t.Errorf("Error loading index.yaml: %w", err)
+		t.Fatalf("error loading index.yaml: %v", err)
 	}
 
 	chartPath := path.Join(testTmpDir, "kafka")
 	err = syncDependencies(chartPath, source.Repo, target, sourceIndex, false)
-	expectedError := "Please sync zookeeper-5.14.3 dependency first"
+	expectedError := "please sync zookeeper-5.14.3 dependency first"
 	if err != nil && err.Error() != expectedError {
-		t.Errorf("Incorrect error, got: \n %s \n, want: \n %s \n", err.Error(), expectedError)
+		t.Errorf("incorrect error, got: \n %s \n, want: \n %s \n", err.Error(), expectedError)
 	}
 }
 
@@ -49,7 +49,7 @@ func TestUpdateRequirementsFile(t *testing.T) {
 
 	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 	if err != nil {
-		t.Errorf("Error creating temporary: %s", testTmpDir)
+		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 
@@ -66,20 +66,20 @@ func TestUpdateRequirementsFile(t *testing.T) {
 
 	requirements, err := ioutil.ReadFile(requirementsFile)
 	if err != nil {
-		t.Errorf("Error reading updated %s file", requirementsFile)
+		t.Fatalf("error reading updated %s file", requirementsFile)
 	}
 
 	newDeps := &dependencies{}
 	err = yaml.Unmarshal(requirements, newDeps)
 	if err != nil {
-		t.Errorf("Error unmarshaling %s file", requirementsFile)
+		t.Fatalf("error unmarshaling %s file", requirementsFile)
 	}
 
 	if newDeps.Dependencies[0].Repository != target.Repo.Url {
-		t.Errorf("Incorrect modification, got: %s, want: %s", newDeps.Dependencies[0].Repository, target.Repo.Url)
+		t.Errorf("incorrect modification, got: %s, want: %s", newDeps.Dependencies[0].Repository, target.Repo.Url)
 	}
 	if newDeps.Dependencies[0].Version != "5.5.5" {
-		t.Errorf("Incorrect modification, got: %s, want: %s", newDeps.Dependencies[0].Version, "5.5.5")
+		t.Errorf("incorrect modification, got: %s, want: %s", newDeps.Dependencies[0].Version, "5.5.5")
 	}
 }
 
@@ -99,7 +99,7 @@ func TestWriteRequirementsFile(t *testing.T) {
 
 	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 	if err != nil {
-		t.Errorf("Error creating temporary: %s", testTmpDir)
+		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 
@@ -112,13 +112,13 @@ func TestWriteRequirementsFile(t *testing.T) {
 	requirementsFile := path.Join(chartPath, "requirements.yaml")
 	requirements, err := ioutil.ReadFile(requirementsFile)
 	if err != nil {
-		t.Errorf("Error reading %s file", requirementsFile)
+		t.Fatalf("error reading %s file", requirementsFile)
 	}
 
 	deps := &dependencies{}
 	err = yaml.Unmarshal(requirements, deps)
 	if err != nil {
-		t.Errorf("Error unmarshaling %s file", requirementsFile)
+		t.Fatalf("error unmarshaling %s file", requirementsFile)
 	}
 
 	deps.Dependencies[0].Repository = target.Repo.Url
@@ -129,20 +129,20 @@ func TestWriteRequirementsFile(t *testing.T) {
 
 	requirements, err = ioutil.ReadFile(requirementsFile)
 	if err != nil {
-		t.Errorf("Error reading updated %s file", requirementsFile)
+		t.Fatalf("error reading updated %s file", requirementsFile)
 	}
 
 	newDeps := &dependencies{}
 	err = yaml.Unmarshal(requirements, newDeps)
 	if err != nil {
-		t.Errorf("Error unmarshaling %s file", requirementsFile)
+		t.Fatalf("error unmarshaling %s file", requirementsFile)
 	}
 
 	if newDeps.Dependencies[0].Repository != target.Repo.Url {
-		t.Errorf("Incorrect modification, got: %s, want: %s", newDeps.Dependencies[0].Repository, target.Repo.Url)
+		t.Errorf("incorrect modification, got: %s, want: %s", newDeps.Dependencies[0].Repository, target.Repo.Url)
 	}
 	if newDeps.Dependencies[0].Version != "5.x.x" {
-		t.Errorf("Incorrect modification, got: %s, want: %s", newDeps.Dependencies[0].Version, "5.x.x")
+		t.Errorf("incorrect modification, got: %s, want: %s", newDeps.Dependencies[0].Version, "5.x.x")
 	}
 }
 
@@ -155,9 +155,9 @@ func TestFindDepByName(t *testing.T) {
 	}
 	dep := findDepByName(deps.Dependencies, "postgresql")
 	if dep.Name != "postgresql" {
-		t.Errorf("Wrong dependency, got: %s , want: %s", dep.Name, "postgresql")
+		t.Errorf("wrong dependency, got: %s , want: %s", dep.Name, "postgresql")
 	}
 	if dep.Version != "4.5.6" {
-		t.Errorf("Wrong dependency, got: %s , want: %s", dep.Version, "4.5.6")
+		t.Errorf("wrong dependency, got: %s , want: %s", dep.Version, "4.5.6")
 	}
 }

--- a/pkg/chart/sync_test.go
+++ b/pkg/chart/sync_test.go
@@ -29,7 +29,7 @@ func TestSync(t *testing.T) {
 
 			sourceIndex, err := utils.LoadIndexFromRepo(source.Repo)
 			if err != nil {
-				t.Errorf("Error loading index.yaml: %w", err)
+				t.Fatalf("error loading index.yaml: %v", err)
 			}
 
 			name := "zookeeper"
@@ -72,9 +72,8 @@ func TestSync(t *testing.T) {
 			if test.Desc == "real service" {
 				// Create temporary working directory
 				testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
-				t.Logf("Working dir is: %s", testTmpDir)
 				if err != nil {
-					t.Errorf("Error creating temporary: %s", testTmpDir)
+					t.Fatalf("error creating temporary: %s", testTmpDir)
 				}
 				defer os.RemoveAll(testTmpDir)
 				// Create client for target repo
@@ -98,10 +97,10 @@ func TestSync(t *testing.T) {
 				expectedRegistryText := "registry: test.registry.io"
 				expectedRepositoryText := "repository: test/repo/zookeeper"
 				if !strings.Contains(valuesText, expectedRegistryText) {
-					t.Errorf("Expected values.yaml file to contain %q", expectedRegistryText)
+					t.Errorf("expected values.yaml file to contain %q", expectedRegistryText)
 				}
 				if !strings.Contains(valuesText, expectedRepositoryText) {
-					t.Errorf("Expected values.yaml file to contain %q", expectedRepositoryText)
+					t.Errorf("expected values.yaml file to contain %q", expectedRepositoryText)
 				}
 			}
 		})
@@ -128,7 +127,7 @@ func TestSyncAllVersions(t *testing.T) {
 				t.Fatal(err)
 			}
 			if err := SyncAllVersions(name, source.Repo, target, false, index, false); err != nil {
-				t.Fatal(err)
+				t.Error(err)
 			}
 		})
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,7 +27,7 @@ func Load(config *api.Config) error {
 
 	err := yamlToProto(viper.ConfigFileUsed(), config)
 	if err != nil {
-		return errors.Trace(fmt.Errorf("Error unmarshalling config file: %w", err))
+		return errors.Trace(fmt.Errorf("error unmarshalling config file: %w", err))
 	}
 	if config.Target.RepoName == "" {
 		klog.Warning("'target.repoName' property is empty. Using 'myrepo' default value")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -14,10 +14,10 @@ func TestLoad(t *testing.T) {
 	viper.SetConfigFile(cfgFile)
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		t.Errorf("Error reading config file: %+v", err)
+		t.Fatalf("error reading config file: %+v", err)
 	}
 	if err := Load(&syncConfig); err != nil {
-		t.Errorf("Error loading config file")
+		t.Fatalf("error loading config file")
 	}
 	source := syncConfig.Source
 	target := syncConfig.Target

--- a/pkg/repo/chartmuseum.go
+++ b/pkg/repo/chartmuseum.go
@@ -48,7 +48,7 @@ func (c *ChartMuseumClient) ChartExists(name string, version string, repo *api.R
 	klog.V(3).Infof("Checking if %s-%s chart exists in %q", name, version, repo.Url)
 	index, err := utils.LoadIndexFromRepo(repo)
 	if err != nil {
-		return false, errors.Trace(fmt.Errorf("Error loading index.yaml: %w", err))
+		return false, errors.Trace(fmt.Errorf("error loading index.yaml: %w", err))
 	}
 	chartExists, err := utils.ChartExistInIndex(name, version, index)
 	if err != nil {

--- a/pkg/repo/chartmuseum_test.go
+++ b/pkg/repo/chartmuseum_test.go
@@ -119,7 +119,7 @@ func TestDownloadFromChartmuseum(t *testing.T) {
 			// Create temporary working directory
 			testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 			if err != nil {
-				t.Errorf("Error creating temporary: %s", testTmpDir)
+				t.Fatalf("error creating temporary: %s", testTmpDir)
 			}
 			defer os.RemoveAll(testTmpDir)
 
@@ -132,7 +132,7 @@ func TestDownloadFromChartmuseum(t *testing.T) {
 				t.Fatal(err)
 			}
 			if _, err := os.Stat(chartPath); err != nil {
-				t.Errorf("Expected %s to exists", chartPath)
+				t.Errorf("expected %s to exists", chartPath)
 			}
 		})
 	}

--- a/pkg/repo/common.go
+++ b/pkg/repo/common.go
@@ -35,7 +35,7 @@ func download(filepath string, downloadURL string, sourceRepo *api.Repo) error {
 
 	// Check status code
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		return errors.Errorf("Error downloading chart %s. Status code is %d", downloadURL, res.StatusCode)
+		return errors.Errorf("error downloading chart %s. Status code is %d", downloadURL, res.StatusCode)
 	}
 	// Create the file
 	out, err := os.Create(filepath)
@@ -113,10 +113,10 @@ func downloadFromChartMuseumLike(apiEndpoint string, filepath string, sourceRepo
 	// Check contentType
 	contentType, err := utils.GetFileContentType(filepath)
 	if err != nil {
-		return errors.Annotatef(err, "Error checking contentType of %s file", filepath)
+		return errors.Trace(err)
 	}
 	if contentType != "application/x-gzip" {
-		return errors.Errorf("The downloaded chart %s is not a gzipped tarball", filepath)
+		return errors.Errorf("the downloaded chart %s is not a gzipped tarball", filepath)
 	}
 	return nil
 }

--- a/pkg/repo/harbor.go
+++ b/pkg/repo/harbor.go
@@ -49,7 +49,7 @@ func (c *HarborClient) ChartExists(name string, version string, repo *api.Repo) 
 	klog.V(3).Infof("Checking if %s-%s chart exists in %q", name, version, repo.Url)
 	index, err := utils.LoadIndexFromRepo(repo)
 	if err != nil {
-		return false, errors.Trace(fmt.Errorf("Error loading index.yaml: %w", err))
+		return false, errors.Trace(fmt.Errorf("error loading index.yaml: %w", err))
 	}
 	chartExists, err := utils.ChartExistInIndex(name, version, index)
 	if err != nil {

--- a/pkg/repo/harbor_test.go
+++ b/pkg/repo/harbor_test.go
@@ -116,7 +116,7 @@ func TestDownloadFromHarbor(t *testing.T) {
 			// Create temporary working directory
 			testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 			if err != nil {
-				t.Errorf("Error creating temporary: %s", testTmpDir)
+				t.Fatalf("error creating temporary: %s", testTmpDir)
 			}
 			defer os.RemoveAll(testTmpDir)
 
@@ -129,7 +129,7 @@ func TestDownloadFromHarbor(t *testing.T) {
 				t.Fatal(err)
 			}
 			if _, err := os.Stat(chartPath); err != nil {
-				t.Errorf("Expected %s to exists", chartPath)
+				t.Errorf("expected %s to exists", chartPath)
 			}
 		})
 	}

--- a/pkg/repo/helmclassic.go
+++ b/pkg/repo/helmclassic.go
@@ -23,7 +23,7 @@ func NewClassicHelmClient(repo *api.Repo) *ClassicHelmClient {
 // PublishChart publishes a packaged chart to classic helm repository.
 func (c *ClassicHelmClient) PublishChart(filepath string, targetRepo *api.Repo) error {
 	klog.V(3).Infof("Publishing %s to classic helm repo", filepath)
-	return errors.Errorf("Publishing to a Helm classic repository is not supported yet")
+	return errors.Errorf("publishing to a Helm classic repository is not supported yet")
 }
 
 // DownloadChart downloads a packaged chart from a classic helm repository.
@@ -39,10 +39,10 @@ func (c *ClassicHelmClient) DownloadChart(filepath string, name string, version 
 	// Check contentType
 	contentType, err := utils.GetFileContentType(filepath)
 	if err != nil {
-		return errors.Annotatef(err, "Error checking contentType of %s file", filepath)
+		return errors.Trace(err)
 	}
 	if contentType != "application/x-gzip" {
-		return errors.Errorf("The downloaded chart %s is not a gzipped tarball", filepath)
+		return errors.Errorf("the downloaded chart %s is not a gzipped tarball", filepath)
 	}
 	return nil
 }
@@ -52,7 +52,7 @@ func (c *ClassicHelmClient) ChartExists(name string, version string, repo *api.R
 	klog.V(3).Infof("Checking if %s-%s chart exists in %q", name, version, repo.Url)
 	index, err := utils.LoadIndexFromRepo(repo)
 	if err != nil {
-		return false, errors.Trace(fmt.Errorf("Error loading index.yaml: %w", err))
+		return false, errors.Trace(fmt.Errorf("error loading index.yaml: %w", err))
 	}
 	chartExists, err := utils.ChartExistInIndex(name, version, index)
 	if err != nil {

--- a/pkg/repo/helmclassic_test.go
+++ b/pkg/repo/helmclassic_test.go
@@ -29,7 +29,7 @@ func TestDownloadFromHelmClassic(t *testing.T) {
 	// Create temporary working directory
 	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 	if err != nil {
-		t.Errorf("Error creating temporary: %s", testTmpDir)
+		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 	chartPath := path.Join(testTmpDir, "nginx-5.3.1.tgz")
@@ -40,13 +40,13 @@ func TestDownloadFromHelmClassic(t *testing.T) {
 	}
 	sourceIndex, err := utils.LoadIndexFromRepo(sourceHelm.Repo)
 	if err != nil {
-		t.Errorf("Error loading index.yaml: %w", err)
+		t.Fatalf("error loading index.yaml: %v", err)
 	}
 	if err := sc.DownloadChart(chartPath, "nginx", "5.3.1", sourceHelm.Repo, sourceIndex); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(chartPath); err != nil {
-		t.Errorf("Expected %s to exists", chartPath)
+		t.Errorf("expected %s to exists", chartPath)
 	}
 }
 
@@ -73,8 +73,8 @@ func TestPublishToHelmClassic(t *testing.T) {
 	}
 	chartPath := "../../testdata/apache-7.3.15.tgz"
 	err = tc.PublishChart(chartPath, targetHelm.Repo)
-	expectedErrorMsg := "Publishing to a Helm classic repository is not supported yet"
+	expectedErrorMsg := "publishing to a Helm classic repository is not supported yet"
 	if err.Error() != expectedErrorMsg {
-		t.Errorf("Incorrect error, got: \n %s \n, want: \n %s \n", err.Error(), expectedErrorMsg)
+		t.Errorf("incorrect error, got: \n %s \n, want: \n %s \n", err.Error(), expectedErrorMsg)
 	}
 }

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -24,10 +24,10 @@ func TestLoadIndexFromRepo(t *testing.T) {
 	// Load index.yaml info into index object
 	sourceIndex, err := LoadIndexFromRepo(source.Repo)
 	if err != nil {
-		t.Errorf("Error loading index.yaml: %w", err)
+		t.Fatalf("error loading index.yaml: %v", err)
 	}
 	if sourceIndex.Entries["apache"] == nil {
-		t.Errorf("Apache chart not found")
+		t.Errorf("apache chart not found")
 	}
 }
 
@@ -35,27 +35,27 @@ func TestChartExistInIndex(t *testing.T) {
 	sampleIndexFile := "../../testdata/index.yaml"
 	index, err := helmRepo.LoadIndexFile(sampleIndexFile)
 	if err != nil {
-		t.Errorf("Error loading index.yaml: %v ", err)
+		t.Fatalf("error loading index.yaml: %v ", err)
 	}
 	versionExist, err := ChartExistInIndex("etcd", "4.7.4", index)
 	versionNotExist, err := ChartExistInIndex("etcd", "0.0.44", index)
 	if versionExist != true {
-		t.Errorf("Version should exist but is not found")
+		t.Errorf("version should exist but is not found")
 	}
 	if versionNotExist != false {
-		t.Errorf("Version should not exist but it is reported as found")
+		t.Errorf("version should not exist but it is reported as found")
 	}
 }
 
 func TestDownloadIndex(t *testing.T) {
 	indexFile, err := downloadIndex(source.Repo)
 	if err != nil {
-		t.Errorf("Error downloading index.yaml: %v ", err)
+		t.Fatalf("error downloading index.yaml: %v ", err)
 	}
 	defer os.Remove(indexFile)
 
 	if _, err := os.Stat(indexFile); err != nil {
-		t.Errorf("Index file does not exist.")
+		t.Errorf("index file does not exist.")
 	}
 }
 
@@ -64,14 +64,14 @@ func TestUntar(t *testing.T) {
 	// Create temporary working directory
 	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
 	if err != nil {
-		t.Errorf("Error creating temporary: %s", testTmpDir)
+		t.Fatalf("error creating temporary: %s", testTmpDir)
 	}
 	defer os.RemoveAll(testTmpDir)
 	if err := Untar(filepath, testTmpDir); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(path.Join(testTmpDir, "apache/Chart.yaml")); err != nil {
-		t.Errorf("Error untaring chart package")
+		t.Error("error untaring chart package")
 	}
 }
 
@@ -79,10 +79,10 @@ func TestGetFileContentType(t *testing.T) {
 	filepath := "../../testdata/apache-7.3.15.tgz"
 	contentType, err := GetFileContentType(filepath)
 	if err != nil {
-		t.Errorf("Error checking contentType of %s file", filepath)
+		t.Fatalf("error checking contentType of %s file", filepath)
 	}
 	if contentType != "application/x-gzip" {
-		t.Errorf("Incorrect content type, got: %s, want: %s.", contentType, "application/x-gzip")
+		t.Errorf("incorrect content type, got: %s, want: %s.", contentType, "application/x-gzip")
 	}
 }
 
@@ -94,7 +94,7 @@ func TestGetDateThreshold(t *testing.T) {
 		t.Fatal(err)
 	}
 	if dateThreshold != date {
-		t.Errorf("Incorrect dateThreshold, expected: %v, got %v", date, dateThreshold)
+		t.Errorf("incorrect dateThreshold, expected: %v, got %v", date, dateThreshold)
 	}
 }
 
@@ -107,12 +107,12 @@ func TestGetDownloadURL(t *testing.T) {
 	}
 	expectedDownloadURL := "https://repo-url.com/charts/apache-7.3.15.tgz"
 	if downloadURL != expectedDownloadURL {
-		t.Errorf("Wrong download URL, got: %s , want: %s", downloadURL, expectedDownloadURL)
+		t.Errorf("wrong download URL, got: %s , want: %s", downloadURL, expectedDownloadURL)
 	}
 	expectedError := "unable to find chart url in index"
 	downloadURL, err = FindChartURL("apache", "0.0.333", sourceIndex)
 	if err.Error() != expectedError {
-		t.Errorf("Wrong error message, got: %s , want: %s", err.Error(), expectedError)
+		t.Errorf("wrong error message, got: %s , want: %s", err.Error(), expectedError)
 	}
 }
 
@@ -121,9 +121,9 @@ func TestFindChartByVersion(t *testing.T) {
 	sourceIndex.Add(&chart.Metadata{Name: "apache", Version: "7.3.15"}, "apache-7.3.15.tgz", "https://repo-url.com/charts", "sha256:1234567890")
 	chart := findChartByVersion(sourceIndex.Entries["apache"], "7.3.15")
 	if chart.Name != "apache" {
-		t.Errorf("Wrong chart, got: %s , want: %s", chart.Name, "apache")
+		t.Errorf("wrong chart, got: %s , want: %s", chart.Name, "apache")
 	}
 	if chart.Version != "7.3.15" {
-		t.Errorf("Wrong chart version, got: %s , want: %s", chart.Version, "7.3.15")
+		t.Errorf("wrong chart version, got: %s , want: %s", chart.Version, "7.3.15")
 	}
 }


### PR DESCRIPTION
Fix #23 

- errors are now **not** capitalized as recommended for golang projects. https://github.com/golang/go/wiki/CodeReviewComments#error-strings
- use `t.Fatal(f)` instead of `t.Error(f)` if it fails a test preparation step instead of the test itself
