### PR TITLE
Fix getting auth properties from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,22 +305,22 @@ The recommended way to specify credentials is using environment variables in the
   - name: charts-syncer
     image: IMAGE_NAME:TAG
     env:
-      - name: SOURCE_REPO_USERNAME
+      - name: SOURCE_AUTH_USERNAME
         valueFrom:
           secretKeyRef:
             name: chart-syncer-credentials
             key: source-username
-      - name: SOURCE_REPO_PASSWORD
+      - name: SOURCE_AUTH_PASSWORD
         valueFrom:
           secretKeyRef:
             name: chart-syncer-credentials
             key: source-password
-      - name: TARGET_REPO_USERNAME
+      - name: TARGET_AUTH_USERNAME
         valueFrom:
           secretKeyRef:
             name: chart-syncer-credentials
             key: target-username
-      - name: TARGET_REPO_PASSWORD
+      - name: TARGET_AUTH_PASSWORD
         valueFrom:
           secretKeyRef:
             name: chart-syncer-credentials

--- a/api/api.go
+++ b/api/api.go
@@ -2,3 +2,24 @@
 
 // Package api provides APIs for syncing a chart repository
 package api
+
+// SetBasicAuth is used configure the auth credentials for Repo kinds
+func (r *Repo) SetBasicAuth(username string, password string) error {
+	// No auth provided, leave as-is
+	if username == "" && password == "" {
+		return nil
+	}
+	// If username or password are already set, the value from
+	// config file has preference over environment variable
+	if r.Auth == nil {
+		r.Auth = &Auth{Username: username, Password: password}
+	} else {
+		if r.Auth.Username == "" {
+			r.Auth.Username = username
+		}
+		if r.Auth.Password == "" {
+			r.Auth.Password = password
+		}
+	}
+	return nil
+}

--- a/api/api.go
+++ b/api/api.go
@@ -9,15 +9,16 @@ func (r *Repo) SetBasicAuth(username string, password string) error {
 	if username == "" && password == "" {
 		return nil
 	}
-	// If username or password are already set, the value from
-	// config file has preference over environment variable
+	// If username or password are already set, the value will
+	// be override with the environment variable one as it
+	// has preference.
 	if r.Auth == nil {
 		r.Auth = &Auth{Username: username, Password: password}
 	} else {
-		if r.Auth.Username == "" {
+		if username != "" {
 			r.Auth.Username = username
 		}
-		if r.Auth.Password == "" {
+		if password != "" {
 			r.Auth.Password = password
 		}
 	}

--- a/deployment/cronjob.yaml
+++ b/deployment/cronjob.yaml
@@ -15,22 +15,22 @@ spec:
             image: IMAGE_NAME:TAG
             args: ["sync", "--config", "/charts-syncer.yaml", "-v", "4"]
             # env:
-            #   - name: SOURCE_REPO_USERNAME
+            #   - name: SOURCE_AUTH_USERNAME
             #     valueFrom:
             #       secretKeyRef:
             #         name: chart-syncer-credentials
             #         key: source-username
-            #   - name: SOURCE_REPO_PASSWORD
+            #   - name: SOURCE_AUTH_PASSWORD
             #     valueFrom:
             #       secretKeyRef:
             #         name: chart-syncer-credentials
             #         key: source-password
-            #   - name: TARGET_REPO_USERNAME
+            #   - name: TARGET_AUTH_USERNAME
             #     valueFrom:
             #       secretKeyRef:
             #         name: chart-syncer-credentials
             #         key: target-username
-            #   - name: TARGET_REPO_PASSWORD
+            #   - name: TARGET_AUTH_PASSWORD
             #     valueFrom:
             #       secretKeyRef:
             #         name: chart-syncer-credentials

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,25 +29,11 @@ func Load(config *api.Config) error {
 		klog.Warning("'target.repoName' property is empty. Using 'myrepo' default value")
 		config.Target.RepoName = defaultRepoName
 	}
-	if config.Source.Repo.Auth == nil {
-		sourceAuth := &api.Auth{}
-		if su := os.Getenv("SOURCE_AUTH_USERNAME"); su != "" {
-			sourceAuth.Username = su
-		}
-		if sp := os.Getenv("SOURCE_AUTH_PASSWORD"); sp != "" {
-			sourceAuth.Password = sp
-		}
-		config.Source.Repo.Auth = sourceAuth
+	if err := config.Source.Repo.SetBasicAuth(os.Getenv("SOURCE_AUTH_USERNAME"), os.Getenv("SOURCE_AUTH_PASSWORD")); err != nil {
+		return err
 	}
-	if config.Target.Repo.Auth == nil {
-		targetAuth := &api.Auth{}
-		if tu := os.Getenv("TARGET_AUTH_USERNAME"); tu != "" {
-			targetAuth.Username = tu
-		}
-		if tp := os.Getenv("TARGET_AUTH_PASSWORD"); tp != "" {
-			targetAuth.Password = tp
-		}
-		config.Target.Repo.Auth = targetAuth
+	if err := config.Target.Repo.SetBasicAuth(os.Getenv("TARGET_AUTH_USERNAME"), os.Getenv("TARGET_AUTH_PASSWORD")); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -97,16 +97,16 @@ func TestGetAuthFromEnvVar(t *testing.T) {
 				"tp": "password456",
 			},
 		},
-		"no-overwrite-user-with-env-var": {
+		"overwrite-user-with-env-var": {
 			"example-config.yaml",
 			map[string]string{
 				"SOURCE_AUTH_USERNAME": "newSourceUserFromEnvVar",
 				"TARGET_AUTH_USERNAME": "newTargetUserFromEnvVar",
 			},
 			map[string]string{
-				"su": "user123",
+				"su": "newSourceUserFromEnvVar",
 				"sp": "password123",
-				"tu": "user456",
+				"tu": "newTargetUserFromEnvVar",
 				"tp": "password456",
 			},
 		},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"os"
 	"testing"
 
 	"github.com/bitnami-labs/charts-syncer/api"
@@ -32,5 +33,37 @@ func TestLoad(t *testing.T) {
 	}
 	if target.ContainerRepository != "user/demo" {
 		t.Errorf("Got: %s, want %s", target.ContainerRepository, "user/demo")
+	}
+}
+
+// Get auth properties from env vars
+func TestGetAuthFromEnvVar(t *testing.T) {
+	var syncConfig api.Config
+	cfgFile := "../../testdata/example-config-no-auth.yaml"
+	viper.SetConfigFile(cfgFile)
+	os.Setenv("SOURCE_AUTH_USERNAME", "sUsername")
+	os.Setenv("SOURCE_AUTH_PASSWORD", "sPassword")
+	os.Setenv("TARGET_AUTH_USERNAME", "tUsername")
+	os.Setenv("TARGET_AUTH_PASSWORD", "tPassword")
+	// If a config file is found, read it in.
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("error reading config file: %+v", err)
+	}
+	if err := Load(&syncConfig); err != nil {
+		t.Fatalf("error loading config file")
+	}
+	source := syncConfig.Source
+	target := syncConfig.Target
+	if source.Repo.Auth.Username != "sUsername" {
+		t.Errorf("Got: %s, want %s", source.Repo.Auth.Username, "sUsername")
+	}
+	if source.Repo.Auth.Password != "sPassword" {
+		t.Errorf("Got: %s, want %s", source.Repo.Auth.Password, "sPassword")
+	}
+	if target.Repo.Auth.Username != "tUsername" {
+		t.Errorf("Got: %s, want %s", target.Repo.Auth.Username, "tUsername")
+	}
+	if target.Repo.Auth.Password != "tPassword" {
+		t.Errorf("Got: %s, want %s", target.Repo.Auth.Password, "tPassword")
 	}
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -38,32 +39,112 @@ func TestLoad(t *testing.T) {
 
 // Get auth properties from env vars
 func TestGetAuthFromEnvVar(t *testing.T) {
-	var syncConfig api.Config
-	cfgFile := "../../testdata/example-config-no-auth.yaml"
-	viper.SetConfigFile(cfgFile)
-	os.Setenv("SOURCE_AUTH_USERNAME", "sUsername")
-	os.Setenv("SOURCE_AUTH_PASSWORD", "sPassword")
-	os.Setenv("TARGET_AUTH_USERNAME", "tUsername")
-	os.Setenv("TARGET_AUTH_PASSWORD", "tPassword")
-	// If a config file is found, read it in.
-	if err := viper.ReadInConfig(); err != nil {
-		t.Fatalf("error reading config file: %+v", err)
+	tests := map[string]struct {
+		inputFile string
+		envVars   map[string]string
+		expected  map[string]string
+	}{
+		"full-env-vars": {
+			"example-config-no-auth.yaml",
+			map[string]string{
+				"SOURCE_AUTH_USERNAME": "sUsername",
+				"SOURCE_AUTH_PASSWORD": "sPassword",
+				"TARGET_AUTH_USERNAME": "tUsername",
+				"TARGET_AUTH_PASSWORD": "tPassword",
+			},
+			map[string]string{
+				"su": "sUsername",
+				"sp": "sPassword",
+				"tu": "tUsername",
+				"tp": "tPassword",
+			},
+		},
+		"full-file": {
+			"example-config.yaml",
+			map[string]string{},
+			map[string]string{
+				"su": "user123",
+				"sp": "password123",
+				"tu": "user456",
+				"tp": "password456",
+			},
+		},
+		"user-file-pass-env": {
+			"example-config-user-file.yaml",
+			map[string]string{
+				"SOURCE_AUTH_PASSWORD": "sourcePassEnv",
+				"TARGET_AUTH_PASSWORD": "targetPassEnv",
+			},
+			map[string]string{
+				"su": "sourceUserFile",
+				"sp": "sourcePassEnv",
+				"tu": "targetUserFile",
+				"tp": "targetPassEnv",
+			},
+		},
+		"full-file-existing-empty-env-vars": {
+			"example-config.yaml",
+			map[string]string{
+				"SOURCE_AUTH_USERNAME": "",
+				"SOURCE_AUTH_PASSWORD": "",
+				"TARGET_AUTH_USERNAME": "",
+				"TARGET_AUTH_PASSWORD": "",
+			},
+			map[string]string{
+				"su": "user123",
+				"sp": "password123",
+				"tu": "user456",
+				"tp": "password456",
+			},
+		},
+		"no-overwrite-user-with-env-var": {
+			"example-config.yaml",
+			map[string]string{
+				"SOURCE_AUTH_USERNAME": "newSourceUserFromEnvVar",
+				"TARGET_AUTH_USERNAME": "newTargetUserFromEnvVar",
+			},
+			map[string]string{
+				"su": "user123",
+				"sp": "password123",
+				"tu": "user456",
+				"tp": "password456",
+			},
+		},
 	}
-	if err := Load(&syncConfig); err != nil {
-		t.Fatalf("error loading config file")
-	}
-	source := syncConfig.Source
-	target := syncConfig.Target
-	if source.Repo.Auth.Username != "sUsername" {
-		t.Errorf("Got: %s, want %s", source.Repo.Auth.Username, "sUsername")
-	}
-	if source.Repo.Auth.Password != "sPassword" {
-		t.Errorf("Got: %s, want %s", source.Repo.Auth.Password, "sPassword")
-	}
-	if target.Repo.Auth.Username != "tUsername" {
-		t.Errorf("Got: %s, want %s", target.Repo.Auth.Username, "tUsername")
-	}
-	if target.Repo.Auth.Password != "tPassword" {
-		t.Errorf("Got: %s, want %s", target.Repo.Auth.Password, "tPassword")
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var syncConfig api.Config
+			cfgFile := fmt.Sprintf("../../testdata/%s", tc.inputFile)
+			viper.SetConfigFile(cfgFile)
+			for k, v := range tc.envVars {
+				os.Setenv(k, v)
+			}
+			// If a config file is found, read it in.
+			if err := viper.ReadInConfig(); err != nil {
+				t.Fatalf("error reading config file: %+v", err)
+			}
+			if err := Load(&syncConfig); err != nil {
+				t.Fatalf("error loading config file")
+			}
+			source := syncConfig.Source
+			target := syncConfig.Target
+			for k := range tc.envVars {
+				os.Unsetenv(k)
+			}
+			if source.Repo.Auth.Username != tc.expected["su"] {
+				t.Errorf("Got: %s, want %s", source.Repo.Auth.Username, tc.expected["su"])
+			}
+			if source.Repo.Auth.Password != tc.expected["sp"] {
+				t.Errorf("Got: %s, want %s", source.Repo.Auth.Password, tc.expected["sp"])
+			}
+			if target.Repo.Auth.Username != tc.expected["tu"] {
+				t.Errorf("Got: %s, want %s", target.Repo.Auth.Username, tc.expected["tu"])
+			}
+			if target.Repo.Auth.Password != tc.expected["tp"] {
+				t.Errorf("Got: %s, want %s", target.Repo.Auth.Password, tc.expected["tp"])
+			}
+
+		})
 	}
 }

--- a/testdata/example-config-no-auth.yaml
+++ b/testdata/example-config-no-auth.yaml
@@ -1,0 +1,13 @@
+#
+# Example config file
+#
+source:
+  repo:
+    kind: HELM
+    url: http://localhost:8080 # local test source repo
+target:
+  containerRegistry: test.registry.io
+  containerRepository: user/demo
+  repo:
+    kind: CHARTMUSEUM
+    url: http://localhost:9090 # local test target repo

--- a/testdata/example-config-user-file.yaml
+++ b/testdata/example-config-user-file.yaml
@@ -1,0 +1,17 @@
+#
+# Example config file
+#
+source:
+  repo:
+    kind: HELM
+    url: http://localhost:8080 # local test source repo
+    auth:
+      username: sourceUserFile
+target:
+  containerRegistry: test.registry.io
+  containerRepository: user/demo
+  repo:
+    kind: CHARTMUSEUM
+    url: http://localhost:9090 # local test target repo
+    auth:
+      username: targetUserFile


### PR DESCRIPTION
Since we stop using viper to unmarshall the config file the method `viper.BindEnv` stop working too and we lost the ability to set auth properties from env vars.

This PR enables the functionality again and adds a test to verify it continues working on future releases.

Fix #31 