### PR TITLE
Lowercase all errors

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -66,7 +66,7 @@ func initConfig() {
 	}
 	// If a config file is found, read it in.
 	if err := viper.ReadInConfig(); err != nil {
-		klog.Fatalf("Error reading config file: %+v", err)
+		klog.Fatalf("error reading config file: %+v", err)
 	} else {
 		klog.Info("Using config file:", viper.ConfigFileUsed())
 	}

--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -20,10 +20,10 @@ var (
 // updateValuesFile performs some substitutions to a given values.yaml file.
 func updateValuesFile(valuesFile string, targetRepo *api.TargetRepo) error {
 	if err := updateContainerImageRegistry(valuesFile, targetRepo); err != nil {
-		return errors.Annotatef(err, "Error updating %s file", valuesFile)
+		return errors.Annotatef(err, "error updating %s file", valuesFile)
 	}
 	if err := updateContainerImageRepository(valuesFile, targetRepo); err != nil {
-		return errors.Annotatef(err, "Error updating %s file", valuesFile)
+		return errors.Annotatef(err, "error updating %s file", valuesFile)
 	}
 	return nil
 }

--- a/pkg/chart/sync.go
+++ b/pkg/chart/sync.go
@@ -50,7 +50,7 @@ func Sync(name string, version string, sourceRepo *api.Repo, target *api.TargetR
 	// Create temporary working directory
 	tmpDir, err := ioutil.TempDir("", "charts-syncer")
 	if err != nil {
-		return errors.Annotatef(err, "Error creating temporary: %s", tmpDir)
+		return errors.Annotatef(err, "error creating temporary: %s", tmpDir)
 	}
 	defer os.RemoveAll(tmpDir)
 	srcDir := path.Join(tmpDir, "src")
@@ -70,24 +70,24 @@ func Sync(name string, version string, sourceRepo *api.Repo, target *api.TargetR
 		return fmt.Errorf("could not create a client for the source repo: %w", err)
 	}
 	if err := sc.DownloadChart(filepath, name, version, sourceRepo, sourceIndex); err != nil {
-		return errors.Annotatef(err, "Error downloading chart %s-%s from source repo", name, version)
+		return errors.Annotatef(err, "error downloading chart %s-%s from source repo", name, version)
 	}
 
 	// Uncompress chart
 	if err := utils.Untar(filepath, destDir); err != nil {
-		return errors.Annotate(err, "Error found in Untar function")
+		return errors.Annotate(err, "error found in Untar function")
 	}
 
 	// If chart has dependencies, check that they are already in the target repo.
 	chartPath := path.Join(destDir, name)
 	if _, err := os.Stat(path.Join(chartPath, RequirementsLockFilename)); err == nil {
 		if err := syncDependencies(chartPath, sourceRepo, target, sourceIndex, targetIndex, APIV1, syncDeps); err != nil {
-			return errors.Annotatef(err, "Error updating dependencies for chart %s-%s", name, version)
+			return errors.Annotatef(err, "error updating dependencies for chart %s-%s", name, version)
 		}
 	}
 	if _, err := os.Stat(path.Join(chartPath, ChartLockFilename)); err == nil {
 		if err := syncDependencies(chartPath, sourceRepo, target, sourceIndex, targetIndex, APIV2, syncDeps); err != nil {
-			return errors.Annotatef(err, "Error updating dependencies for chart %s-%s", name, version)
+			return errors.Annotatef(err, "error updating dependencies for chart %s-%s", name, version)
 		}
 	}
 
@@ -117,7 +117,7 @@ func Sync(name string, version string, sourceRepo *api.Repo, target *api.TargetR
 	// Package chart
 	packagedChartPath, err := helmcli.Package(chartPath, name, version, destDir)
 	if err != nil {
-		return errors.Annotate(err, "Error taring chart")
+		return errors.Annotate(err, "error taring chart")
 	}
 
 	// Create client for target repo
@@ -126,7 +126,7 @@ func Sync(name string, version string, sourceRepo *api.Repo, target *api.TargetR
 		return fmt.Errorf("could not create a client for the source repo: %w", err)
 	}
 	if err := tc.PublishChart(packagedChartPath, target.Repo); err != nil {
-		return errors.Annotatef(err, "Error publishing chart %s-%s to target repo", name, version)
+		return errors.Annotatef(err, "error publishing chart %s-%s to target repo", name, version)
 	}
 	// Add just synced chart to our local target index so other charts that may have this as dependency
 	// know it is already synced in the target repository.

--- a/pkg/helmcli/helmcli.go
+++ b/pkg/helmcli/helmcli.go
@@ -30,7 +30,7 @@ func UpdateDependencies(chartPath string) error {
 	}
 	cmd := exec.Command("helm", "dependency", "update", chartPath)
 	if _, err := cmd.Output(); err != nil {
-		return errors.Errorf("Error updading dependencies for %s", chartPath)
+		return errors.Errorf("error updading dependencies for %s", chartPath)
 	}
 	return nil
 }
@@ -46,7 +46,7 @@ func AddRepoToHelm(url string, auth *api.Auth) error {
 		cmd = exec.Command("helm", "repo", "add", "target", url)
 	}
 	if _, err := cmd.Output(); err != nil {
-		return errors.Annotate(err, "Error adding target repo to helm")
+		return errors.Annotate(err, "error adding target repo to helm")
 	}
 	return nil
 }

--- a/pkg/repo/common.go
+++ b/pkg/repo/common.go
@@ -20,7 +20,7 @@ func download(filepath string, downloadURL string, sourceRepo *api.Repo) error {
 	req, err := http.NewRequest("GET", downloadURL, nil)
 	klog.V(4).Infof("GET %q", downloadURL)
 	if err != nil {
-		return errors.Annotatef(err, "Error getting chart from %q", downloadURL)
+		return errors.Annotatef(err, "error getting chart from %q", downloadURL)
 	}
 	if sourceRepo.Auth != nil && sourceRepo.Auth.Username != "" && sourceRepo.Auth.Password != "" {
 		klog.V(4).Infof("Using basic authentication %q:****", sourceRepo.Auth.Username)
@@ -29,7 +29,7 @@ func download(filepath string, downloadURL string, sourceRepo *api.Repo) error {
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
-		return errors.Annotate(err, "Error doing request")
+		return errors.Annotate(err, "error doing request")
 	}
 	defer res.Body.Close()
 
@@ -40,13 +40,13 @@ func download(filepath string, downloadURL string, sourceRepo *api.Repo) error {
 	// Create the file
 	out, err := os.Create(filepath)
 	if err != nil {
-		return errors.Annotatef(err, "Error creating %s file", filepath)
+		return errors.Annotatef(err, "error creating %s file", filepath)
 	}
 	defer out.Close()
 
 	// Write the body to file
 	if _, err = io.Copy(out, res.Body); err != nil {
-		return errors.Annotatef(err, "Error write to file %s", filepath)
+		return errors.Annotatef(err, "error write to file %s", filepath)
 	}
 
 	return errors.Trace(err)
@@ -59,12 +59,12 @@ func pushToChartMuseumLike(apiEndpoint string, filepath string, targetRepo *api.
 
 	fileWriter, err := bodyWriter.CreateFormFile("chart", filepath)
 	if err != nil {
-		return errors.Annotate(err, "Error writing to buffer")
+		return errors.Annotate(err, "error writing to buffer")
 	}
 
 	fh, err := os.Open(filepath)
 	if err != nil {
-		return errors.Annotatef(err, "Error opening file %s", filepath)
+		return errors.Annotatef(err, "error opening file %s", filepath)
 	}
 	defer fh.Close()
 
@@ -80,7 +80,7 @@ func pushToChartMuseumLike(apiEndpoint string, filepath string, targetRepo *api.
 	klog.V(4).Infof("POST %q", apiEndpoint)
 	req.Header.Add("content-type", contentType)
 	if err != nil {
-		return errors.Annotatef(err, "Error creating POST request to %s", apiEndpoint)
+		return errors.Annotatef(err, "error creating POST request to %s", apiEndpoint)
 	}
 	if targetRepo.Auth != nil && targetRepo.Auth.Username != "" && targetRepo.Auth.Password != "" {
 		klog.V(4).Info("Target repo uses basic authentication...")
@@ -89,12 +89,12 @@ func pushToChartMuseumLike(apiEndpoint string, filepath string, targetRepo *api.
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
-		return errors.Annotatef(err, "Error doing POST request to %s", apiEndpoint)
+		return errors.Annotatef(err, "error doing POST request to %s", apiEndpoint)
 	}
 	defer res.Body.Close()
 	respBody, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return errors.Annotatef(err, "Error reading POST response from %s", apiEndpoint)
+		return errors.Annotatef(err, "error reading POST response from %s", apiEndpoint)
 	}
 	klog.V(4).Infof("POST chart status Code: %d, Message: %s", res.StatusCode, string(respBody))
 	if res.StatusCode >= 200 && res.StatusCode <= 299 {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -79,7 +79,7 @@ func downloadIndex(repo *api.Repo) (string, error) {
 	defer res.Body.Close()
 	// Check status code
 	if res.StatusCode < 200 || res.StatusCode > 299 {
-		return "", errors.Errorf("Error downloading index.yaml from %s. Status code is %d", repo.Url, res.StatusCode)
+		return "", errors.Errorf("error downloading index.yaml from %s. Status code is %d", repo.Url, res.StatusCode)
 	}
 
 	// Create the file
@@ -100,7 +100,7 @@ func Untar(filepath, destDir string) error {
 	cmd := exec.Command("tar", "xzf", filepath, "--directory", destDir)
 	_, err := cmd.Output()
 	if err != nil {
-		return errors.Annotatef(err, "Error untaring chart package %s", filepath)
+		return errors.Annotatef(err, "error untaring chart package %s", filepath)
 	}
 	return errors.Trace(err)
 }


### PR DESCRIPTION
As recommended in the Golang code review conventions, errors string should not be capitalized.

https://github.com/golang/go/wiki/CodeReviewComments#error-strings