### PR TITLE
feat(syncer): Add topological sort for charts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/juju/testing v0.0.0-20200923013621-75df6121fbb0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mkmik/multierror v0.3.0
+	github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -464,6 +464,8 @@ github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/9
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
+github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f h1:WyCn68lTiytVSkk7W1K9nBiSGTSRlUOdyTnSjwrIlok=
+github.com/philopon/go-toposort v0.0.0-20170620085441-9be86dbd762f/go.mod h1:/iRjX3DdSK956SzsUdV55J+wIsQ+2IBWmBrB4RvZfk4=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1-0.20171018195549-f15c970de5b7/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -131,7 +131,7 @@ func (r *Repo) List() ([]string, error) {
 func (r *Repo) ListChartVersions(name string) ([]string, error) {
 	cv, ok := r.index.Entries[name]
 	if !ok {
-		return []string{}, errors.Errorf("%q has no versions", name)
+		return []string{}, nil
 	}
 
 	var versions []string

--- a/pkg/syncer/index.go
+++ b/pkg/syncer/index.go
@@ -1,0 +1,216 @@
+package syncer
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/mkmik/multierror"
+	toposort "github.com/philopon/go-toposort"
+	"k8s.io/klog"
+
+	"github.com/bitnami-labs/charts-syncer/pkg/chart"
+	"github.com/bitnami-labs/charts-syncer/pkg/utils"
+)
+
+// Chart describes a chart, including dependencies
+type Chart struct {
+	Name         string
+	Version      string
+	Dependencies []string
+
+	TgzPath string
+}
+
+// ChartIndex is a map linking a chart reference with its Chart
+type ChartIndex map[string]*Chart
+
+// getIndex returns the chart index
+func (s *Syncer) getIndex() ChartIndex {
+	if s.index == nil {
+		s.index = make(ChartIndex)
+	}
+	return s.index
+}
+
+// Add adds a chart in the index
+func (i ChartIndex) Add(id string, chart *Chart) error {
+	if _, ok := i[id]; ok {
+		return errors.Errorf("%q is already indexed", id)
+	}
+	i[id] = chart
+	return nil
+}
+
+// Get returns an index chart
+func (i ChartIndex) Get(id string) *Chart {
+	if c, ok := i[id]; ok {
+		return c
+	}
+	return nil
+}
+
+// loadChartsIndex loads the charts map into the index from the source repo
+func (s *Syncer) loadChartsIndex(charts ...string) error {
+	if len(charts) == 0 {
+		if !s.autoDiscovery {
+			return errors.Errorf("unable to discover charts to sync")
+		}
+
+		srcCharts, err := s.cli.src.List()
+		if err != nil {
+			return errors.Trace(err)
+		}
+		charts = srcCharts
+	}
+	// Sort chart names
+	sort.Strings(charts)
+
+	// Create basic layout for date and parse flag to time type
+	publishingThreshold, err := utils.GetDateThreshold(s.fromDate)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	klog.V(4).Infof("Publishing threshold set to %q", publishingThreshold.String())
+
+	// Iterate over charts in source index
+	var errs error
+	for _, name := range charts {
+		versions, err := s.cli.src.ListChartVersions(name)
+		if err != nil {
+			errs = multierror.Append(errs, errors.Trace(err))
+			continue
+		}
+
+		klog.V(5).Infof("Found %d versions for %q chart: %v", len(versions), name, versions)
+		klog.V(3).Infof("Indexing %q charts...", name)
+		for _, version := range versions {
+			details, err := s.cli.src.GetChartDetails(name, version)
+			if err != nil {
+				errs = multierror.Append(errs, errors.Trace(err))
+				continue
+			}
+
+			id := fmt.Sprintf("%s-%s", name, version)
+			klog.V(5).Infof("Details for %q chart: %+v", id, details)
+			if details.PublishedAt.Before(publishingThreshold) {
+				klog.V(4).Infof("Skipping %q chart: Published before %q", id, publishingThreshold.String())
+				continue
+			}
+
+			if ok, err := s.cli.dst.Has(name, version); err != nil {
+				klog.Errorf("unable to explore target repo to check %q chart: %v", id, err)
+				errs = multierror.Append(errs, errors.Trace(err))
+				continue
+			} else if ok {
+				klog.V(4).Infof("Skipping %q chart: Already synced", id)
+				continue
+			}
+
+			if ch := s.getIndex().Get(id); ch != nil {
+				klog.V(4).Infof("Skipping %q chart: Already indexed", id)
+				continue
+			}
+
+			if err := s.loadChart(name, version); err != nil {
+				klog.Errorf("unable to load %q chart: %v", id, err)
+				errs = multierror.Append(errs, errors.Trace(err))
+				continue
+			}
+		}
+	}
+
+	return errors.Trace(errs)
+}
+
+// loadChart loads a chart in the chart index map
+func (s *Syncer) loadChart(name string, version string) error {
+	id := fmt.Sprintf("%s-%s", name, version)
+	// loadChart is a recursive function and it will be invoked again for each
+	// dependency.
+	//
+	// It makes sense that different "tier1" charts use the same "tier2" chart
+	// dependencies. This check will make the method to skip already indexed
+	// charts.
+	//
+	// Example:
+	// `wordpress` is a "tier1" chart that depends on the "tier2" charts `mariadb`
+	// and `common`. `magento` is a "tier1" chart that depends on the "tier2"
+	// charts `mariadb` and `elasticsearch`.
+	//
+	// If we run charts-syncer for `wordpress` and `magento`, this check will
+	// avoid re-indexing `mariadb` twice.
+	if ch := s.getIndex().Get(id); ch != nil {
+		klog.V(4).Infof("Skipping %q chart: Already indexed", id)
+		return nil
+	}
+
+	// Create temporary working directory
+	workdir, err := ioutil.TempDir("", "charts-syncer")
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer os.RemoveAll(workdir)
+
+	tgz := path.Join(workdir, fmt.Sprintf("%s-%s.tgz", name, version))
+	if err := s.cli.src.Fetch(tgz, name, version); err != nil {
+		return errors.Trace(err)
+	}
+
+	ch := &Chart{
+		Name:    name,
+		Version: version,
+		TgzPath: tgz,
+	}
+
+	deps, err := chart.GetChartDependencies(tgz, name)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if len(deps) == 0 {
+		klog.V(4).Infof("Indexing %q chart", id)
+		return errors.Trace(s.getIndex().Add(id, ch))
+	}
+
+	var errs error
+	for _, dep := range deps {
+		depID := fmt.Sprintf("%s-%s", dep.Name, dep.Version)
+		if err := s.loadChart(dep.Name, dep.Version); err != nil {
+			klog.Errorf("unable to load %q dependency chart: %v", depID, err)
+			errs = multierror.Append(errs, errors.Trace(err))
+			continue
+		}
+		ch.Dependencies = append(ch.Dependencies, depID)
+	}
+
+	klog.V(4).Infof("Indexing %q chart", id)
+	return errors.Trace(s.getIndex().Add(id, ch))
+}
+
+// topologicalSortCharts returns the indexed charts, topologically sorted.
+func (s *Syncer) topologicalSortCharts() ([]*Chart, error) {
+	graph := toposort.NewGraph(len(s.getIndex()))
+	for name := range s.getIndex() {
+		graph.AddNode(name)
+	}
+	for name, ch := range s.getIndex() {
+		for _, dep := range ch.Dependencies {
+			graph.AddEdge(dep, name)
+		}
+	}
+
+	result, ok := graph.Toposort()
+	if !ok {
+		return nil, errors.Errorf("dependency cycle detected in charts")
+	}
+
+	charts := make([]*Chart, len(result))
+	for i, id := range result {
+		charts[i] = s.getIndex().Get(id)
+	}
+	return charts, nil
+}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -23,6 +23,10 @@ type Syncer struct {
 	dryRun        bool
 	autoDiscovery bool
 	fromDate      string
+
+	// TODO(jdrios): Cache index (and tgz files) in local filesystem to speed
+	// up re-runs
+	index ChartIndex
 }
 
 // Option is an option value used to create a new syncer instance.


### PR DESCRIPTION
This patch adds [topological sort](https://en.wikipedia.org/wiki/Topological_sorting) capabilities to the `Syncer`.

This allows the `Syncer` to compute the list of charts to synchronize in a way that eases the subsequent uploads to the target chart repository.