### PR TITLE
feat(syncer): Add SyncPendingCharts method

### DIFF
--- a/cmd/syncpending.go
+++ b/cmd/syncpending.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/juju/errors"
 	"github.com/spf13/cobra"
 
@@ -11,6 +13,7 @@ import (
 
 var (
 	syncPendingFromDate string
+	syncPendingWorkdir  string
 )
 
 func newSyncPendingCmd() *cobra.Command {
@@ -40,6 +43,7 @@ func newSyncPendingCmd() *cobra.Command {
 				syncer.WithAutoDiscovery(true),
 				syncer.WithDryRun(rootDryRun),
 				syncer.WithFromDate(syncPendingFromDate),
+				syncer.WithWorkdir(syncPendingWorkdir),
 			)
 			if err != nil {
 				return errors.Trace(err)
@@ -50,6 +54,7 @@ func newSyncPendingCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&syncPendingFromDate, "from-date", "", "Date you want to synchronize charts from. Format: YYYY-MM-DD")
+	cmd.Flags().StringVar(&syncPendingWorkdir, "workdir", syncer.DefaultWorkdir(), fmt.Sprintf("Working directory. Default: %q", syncer.DefaultWorkdir()))
 
 	return cmd
 }

--- a/cmd/syncpending.go
+++ b/cmd/syncpending.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/juju/errors"
 	"github.com/spf13/cobra"
 

--- a/cmd/syncpending.go
+++ b/cmd/syncpending.go
@@ -54,7 +54,7 @@ func newSyncPendingCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&syncPendingFromDate, "from-date", "", "Date you want to synchronize charts from. Format: YYYY-MM-DD")
-	cmd.Flags().StringVar(&syncPendingWorkdir, "workdir", syncer.DefaultWorkdir(), fmt.Sprintf("Working directory. Default: %q", syncer.DefaultWorkdir()))
+	cmd.Flags().StringVar(&syncPendingWorkdir, "workdir", syncer.DefaultWorkdir(), "Working directory.")
 
 	return cmd
 }

--- a/pkg/syncer/index.go
+++ b/pkg/syncer/index.go
@@ -149,7 +149,7 @@ func (s *Syncer) loadChart(name string, version string) error {
 
 	tgz := path.Join(s.srcWorkdir, fmt.Sprintf("%s-%s.tgz", name, version))
 
-	// Fetch chart iff it does not exists in the workdir already
+	// Fetch chart iff it does not exist in the workdir already
 	if ok, err := utils.FileExists(tgz); err != nil {
 		return errors.Trace(err)
 	} else if !ok {

--- a/pkg/syncer/workdir.go
+++ b/pkg/syncer/workdir.go
@@ -1,0 +1,31 @@
+package syncer
+
+import (
+	"os"
+	"path"
+
+	homedir "github.com/mitchellh/go-homedir"
+)
+
+// WorkdirName is the default name for a workdir
+const WorkdirName = ".charts-syncer"
+
+// DefaultWorkdir returns the default workdir path
+func DefaultWorkdir() string {
+	// We are ignoring errors here as they don't really matter for the purpose
+	// of the function
+
+	// Try to assign home as workdir
+	home, _ := homedir.Dir()
+	if home != "" {
+		return path.Join(home, WorkdirName)
+	}
+
+	// Try to assign the current directory as workdir
+	cwd, _ := os.Getwd()
+	if cwd != "" {
+		return path.Join(cwd, WorkdirName)
+	}
+
+	return WorkdirName
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -169,3 +169,14 @@ func isValidURL(text string) bool {
 	}
 	return true
 }
+
+// FileExists will test if a file exists
+func FileExists(f string) (bool, error) {
+	if _, err := os.Stat(f); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Trace(err)
+	}
+	return true, nil
+}


### PR DESCRIPTION
The current `Syncer` stores charts in a temporary folder. This patch adds a local working directory to prevent downloading the charts over and over in each run.

This is not especially useful for a real case usage of this tool in which we will only download a big number of charts the first time syncing two chart repos. We can consider that subsequent runs will download only a few of them. In any case, subcharts (dependencies) might be the same in these subsequent runs, so it still makes sense to add this feature to improve the performance of the tool in real cases.

The reality is that this is extremely useful to speed up the development process.

Example:

```shell
❯ echo -n https://charts.bitnami.com/bitnami | sha1sum -t
cc54f5167101a3913ef8e9c2aff515129771b204  -

❯ tree ~/.charts-syncer/
/Users/jdrios/.charts-syncer/
└── cc54f5167101a3913ef8e9c2aff515129771b204
    ├── common-0.7.1.tgz
    ├── common-0.8.0.tgz
    ├── common-1.0.0.tgz
    ├── common-1.0.1.tgz
    ├── ghost-10.1.15.tgz
    ├── ghost-10.1.16.tgz
    ├── ghost-10.1.17.tgz
    ├── ghost-10.1.18.tgz
    ├── ghost-10.1.19.tgz
    ├── ghost-10.1.20.tgz
    ├── ghost-10.2.0.tgz
    ├── ghost-10.2.1.tgz
    ├── ghost-10.2.2.tgz
    ├── ghost-10.2.3.tgz
    ├── ghost-11.0.0.tgz
    ├── mariadb-7.10.3.tgz
    ├── mariadb-7.10.4.tgz
    └── mariadb-9.0.1.tgz

1 directory, 18 files
```