### PR TITLE
feat(syncer): Add sync pending logic

### DIFF
--- a/pkg/chart/chart.go
+++ b/pkg/chart/chart.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/juju/errors"
-	"k8s.io/klog"
 
 	"github.com/bitnami-labs/charts-syncer/api"
 )
@@ -66,7 +65,6 @@ func updateContainerImageRegistry(valuesFile string, targetRepo *api.TargetRepo)
 
 // updateReadmeFile performs some substitutions to a given README.md file.
 func updateReadmeFile(readmeFile, sourceURL, targetURL, chartName, repoName string) error {
-	klog.V(3).Infof("Updating README file")
 	readme, err := ioutil.ReadFile(readmeFile)
 	if err != nil {
 		return errors.Trace(err)
@@ -83,7 +81,6 @@ func updateReadmeFile(readmeFile, sourceURL, targetURL, chartName, repoName stri
 	}
 	submatch := regex.FindStringSubmatch(string(readme))
 	if len(submatch) > 0 {
-		klog.V(4).Infof("Updating bitnami/ references")
 		replaceText := fmt.Sprintf("%s%s/%s%s", submatch[1], repoName, chartName, submatch[3])
 		newContent = regex.ReplaceAllString(newContent, replaceText)
 	}

--- a/pkg/chart/sync.go
+++ b/pkg/chart/sync.go
@@ -156,7 +156,7 @@ func ChangeReferences(outDir string, filepath string, name string, version strin
 	// Package chart again
 	//
 	// TODO(jdrios): This relies on the helm client to package the repo. It
-	// does not take into account that the targe repo could be out of sync yet
+	// does not take into account that the target repo could be out of sync yet
 	// (for example, if we uploaded a dependency of the chart being packaged a
 	// few seconds ago).
 	newTgz, err := helmcli.Package(chartPath, name, version, outDir)

--- a/pkg/client/harbor/harbor.go
+++ b/pkg/client/harbor/harbor.go
@@ -15,13 +15,8 @@ import (
 	"github.com/bitnami-labs/charts-syncer/api"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/helmclassic"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
+	"github.com/bitnami-labs/charts-syncer/pkg/utils"
 )
-
-func readErrorBody(r io.Reader) string {
-	var s strings.Builder
-	_, _ = io.Copy(&s, r)
-	return s.String()
-}
 
 // Repo allows to operate a chart repository.
 type Repo struct {
@@ -94,7 +89,8 @@ func (r *Repo) Upload(filepath string) error {
 		req.SetBasicAuth(r.username, r.password)
 	}
 
-	klog.V(4).Infof("POST %q", u)
+	reqID := utils.EncodeSha1(u + filepath)
+	klog.V(4).Infof("[%s] POST %q", reqID, u)
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
@@ -102,11 +98,11 @@ func (r *Repo) Upload(filepath string) error {
 	}
 	defer res.Body.Close()
 
-	// Check status code
-	if res.StatusCode == http.StatusNotFound {
-		errorBody := readErrorBody(res.Body)
-		return errors.Errorf("unable to upload %q chart, got HTTP Status: %s, Resp: %v", filepath, res.Status, errorBody)
+	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
+		bodyStr := utils.HTTPResponseBody(res)
+		return errors.Errorf("unable to fetch index.yaml, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
 	}
+	klog.V(4).Infof("[%s] Got HTTP Status: %s", reqID, res.Status)
 
 	return nil
 }

--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -163,7 +163,7 @@ func (r *Repo) Fetch(filename string, name string, version string) error {
 
 	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
 		bodyStr := utils.HTTPResponseBody(res)
-		return errors.Errorf("unable to fetch %s:%s chart, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
+		return errors.Errorf("unable to fetch %s:%s chart, got HTTP Status: %s, Resp: %v", name, version, res.Status, bodyStr)
 	}
 	klog.V(4).Infof("[%s] Got HTTP Status: %s", reqID, res.Status)
 

--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 
 	"github.com/juju/errors"
 	"helm.sh/helm/v3/pkg/repo"

--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -14,13 +14,8 @@ import (
 
 	"github.com/bitnami-labs/charts-syncer/api"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
+	"github.com/bitnami-labs/charts-syncer/pkg/utils"
 )
-
-func readErrorBody(r io.Reader) string {
-	var s strings.Builder
-	_, _ = io.Copy(&s, r)
-	return s.String()
-}
 
 // Repo allows to operate a chart repository.
 type Repo struct {
@@ -43,7 +38,8 @@ var reloadIndex = func(r *Repo) error {
 		req.SetBasicAuth(r.username, r.password)
 	}
 
-	klog.V(4).Infof("GET %q", u)
+	reqID := utils.EncodeSha1(u + "index.yaml")
+	klog.V(4).Infof("[%s] GET %q", reqID, u)
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
@@ -51,11 +47,11 @@ var reloadIndex = func(r *Repo) error {
 	}
 	defer res.Body.Close()
 
-	// Check status code
-	if res.StatusCode == http.StatusNotFound {
-		errorBody := readErrorBody(res.Body)
-		return errors.Errorf("unable to fetch index.yaml, got HTTP Status: %s, Resp: %v", res.Status, errorBody)
+	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
+		bodyStr := utils.HTTPResponseBody(res)
+		return errors.Errorf("unable to fetch index.yaml, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
 	}
+	klog.V(4).Infof("[%s] Got HTTP Status: %s", reqID, res.Status)
 
 	// Create the index.yaml file to use the helm Go library, which does not
 	// expose a Loader from bytes.
@@ -75,7 +71,7 @@ var reloadIndex = func(r *Repo) error {
 
 	index, err := repo.LoadIndexFile(f.Name())
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "loading index.yaml file")
 	}
 
 	r.index = index
@@ -157,7 +153,8 @@ func (r *Repo) Fetch(filename string, name string, version string) error {
 		req.SetBasicAuth(r.username, r.password)
 	}
 
-	klog.V(4).Infof("GET %q", u)
+	reqID := utils.EncodeSha1(u + filename)
+	klog.V(4).Infof("[%s] GET %q", reqID, u)
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
@@ -165,11 +162,11 @@ func (r *Repo) Fetch(filename string, name string, version string) error {
 	}
 	defer res.Body.Close()
 
-	// Check status code
-	if res.StatusCode == http.StatusNotFound {
-		errorBody := readErrorBody(res.Body)
-		return errors.Errorf("unable to fetch %s:%s chart, got HTTP Status: %s, Resp: %v", name, version, res.Status, errorBody)
+	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
+		bodyStr := utils.HTTPResponseBody(res)
+		return errors.Errorf("unable to fetch %s:%s chart, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
 	}
+	klog.V(4).Infof("[%s] Got HTTP Status: %s", reqID, res.Status)
 
 	// Create the file
 	f, err := os.Create(filename)

--- a/pkg/helmcli/helmcli.go
+++ b/pkg/helmcli/helmcli.go
@@ -36,17 +36,27 @@ func UpdateDependencies(chartPath string) error {
 }
 
 // AddRepoToHelm uses helm cli to add a repo to the helm CLI.
-func AddRepoToHelm(url string, auth *api.Auth) error {
+func AddRepoToHelm(name string, url string, auth *api.Auth) error {
 	var cmd *exec.Cmd
 	if auth != nil && auth.Username != "" && auth.Password != "" {
 		klog.V(3).Info("Adding target repository to helm cli with basic authentication")
-		cmd = exec.Command("helm", "repo", "add", "target", url, "--username", auth.Username, "--password", auth.Password)
+		cmd = exec.Command("helm", "repo", "add", name, url, "--username", auth.Username, "--password", auth.Password)
 	} else {
 		klog.V(3).Info("Adding target repository to helm cli")
-		cmd = exec.Command("helm", "repo", "add", "target", url)
+		cmd = exec.Command("helm", "repo", "add", name, url)
 	}
 	if _, err := cmd.Output(); err != nil {
 		return errors.Annotate(err, "error adding target repo to helm")
+	}
+	return nil
+}
+
+// DeleteHelmRepo uses helm cli to delete a repo from the helm CLI.
+func DeleteHelmRepo(name string) error {
+	klog.V(3).Info("Removing target repository from helm cli")
+	cmd := exec.Command("helm", "repo", "remove", name)
+	if _, err := cmd.Output(); err != nil {
+		return errors.Annotate(err, "error removing target repo from helm")
 	}
 	return nil
 }

--- a/pkg/syncer/index.go
+++ b/pkg/syncer/index.go
@@ -1,7 +1,6 @@
 package syncer
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"path"
 	"sort"
@@ -211,10 +210,4 @@ func (s *Syncer) topologicalSortCharts() ([]*Chart, error) {
 		charts[i] = s.getIndex().Get(id)
 	}
 	return charts, nil
-}
-
-func encodeSha1(s string) string {
-	h := sha1.New()
-	h.Write([]byte(s))
-	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitnami-labs/charts-syncer/api"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/core"
+	"github.com/bitnami-labs/charts-syncer/pkg/utils"
 )
 
 // Clients holds the source and target chart repo clients
@@ -120,7 +121,7 @@ func New(source *api.SourceRepo, target *api.TargetRepo, opts ...Option) (*Synce
 	// In order to store charts tgz files in an isolated folder for each chart
 	// repo we are computing a workdir using the hash of the source repo URL
 	// and the pre-configured workdir.
-	s.srcWorkdir = path.Join(s.workdir, encodeSha1(source.GetRepo().GetUrl()))
+	s.srcWorkdir = path.Join(s.workdir, utils.EncodeSha1(source.GetRepo().GetUrl()))
 	if err := os.MkdirAll(s.srcWorkdir, 0755); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -8,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/bitnami-labs/charts-syncer/api"
@@ -179,4 +181,18 @@ func FileExists(f string) (bool, error) {
 		return false, errors.Trace(err)
 	}
 	return true, nil
+}
+
+// HTTPResponseBody returns the body of an HTTP response
+func HTTPResponseBody(res *http.Response) string {
+	var s strings.Builder
+	_, _ = io.Copy(&s, res.Body)
+	return s.String()
+}
+
+// EncodeSha1 returns a SHA1 representation of the provided string
+func EncodeSha1(s string) string {
+	h := sha1.New()
+	h.Write([]byte(s))
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/test/install-ghost.sh
+++ b/test/install-ghost.sh
@@ -3,6 +3,8 @@
 set -o nounset
 set -o pipefail
 
+helm repo remove target || true
+helm repo add target http://127.0.0.1:8080 --username admin --password dummypassword
 helm repo update
 helm search repo target/ghost
 helm install --wait ghost-test target/ghost --set ghostHost=127.0.0.1 --set service.type=ClusterIP


### PR DESCRIPTION
This patch adds the core logic for syncing pending charts.

```shell
❯ ./dist/charts-syncer --config test/test-config.yaml sync-pending --from-date 2020-10-01
I1125 12:21:35.263726   50802 sync.go:32] Using config file: "test/test-config.yaml"
W1125 12:21:35.264320   50802 config.go:29] 'target.repoName' property is empty. Using 'myrepo' default value
I1125 12:21:37.526413   50802 sync.go:107] There are 18 charts out of sync!
I1125 12:21:37.526428   50802 sync.go:118] Syncing "common-0.7.1" chart...
I1125 12:21:37.597341   50802 sync.go:118] Syncing "common-1.0.1" chart...
I1125 12:21:37.684631   50802 sync.go:118] Syncing "mariadb-7.10.3" chart...
I1125 12:21:37.775901   50802 sync.go:118] Syncing "common-0.8.0" chart...
I1125 12:21:37.852975   50802 sync.go:118] Syncing "common-1.0.0" chart...
I1125 12:21:37.932774   50802 sync.go:118] Syncing "mariadb-7.10.4" chart...
I1125 12:21:38.016551   50802 sync.go:118] Syncing "ghost-10.1.15" chart...
I1125 12:21:38.112427   50802 sync.go:118] Syncing "mariadb-9.0.1" chart...
I1125 12:21:38.206013   50802 sync.go:118] Syncing "ghost-10.1.20" chart...
I1125 12:21:38.303267   50802 sync.go:118] Syncing "ghost-10.1.18" chart...
I1125 12:21:38.398802   50802 sync.go:118] Syncing "ghost-10.1.17" chart...
I1125 12:21:38.501794   50802 sync.go:118] Syncing "ghost-10.1.16" chart...
I1125 12:21:38.601411   50802 sync.go:118] Syncing "ghost-10.2.3" chart...
I1125 12:21:38.705479   50802 sync.go:118] Syncing "ghost-10.2.2" chart...
I1125 12:21:38.814234   50802 sync.go:118] Syncing "ghost-10.2.0" chart...
I1125 12:21:38.914943   50802 sync.go:118] Syncing "ghost-10.2.1" chart...
I1125 12:21:39.016934   50802 sync.go:118] Syncing "ghost-10.1.19" chart...
I1125 12:21:39.131117   50802 sync.go:118] Syncing "ghost-11.0.0" chart...
```