### PR TITLE
feat(client): Improve HTTP response handling

### DIFF
--- a/pkg/client/harbor/harbor.go
+++ b/pkg/client/harbor/harbor.go
@@ -15,13 +15,8 @@ import (
 	"github.com/bitnami-labs/charts-syncer/api"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/helmclassic"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
+	"github.com/bitnami-labs/charts-syncer/pkg/utils"
 )
-
-func readErrorBody(r io.Reader) string {
-	var s strings.Builder
-	_, _ = io.Copy(&s, r)
-	return s.String()
-}
 
 // Repo allows to operate a chart repository.
 type Repo struct {
@@ -94,7 +89,8 @@ func (r *Repo) Upload(filepath string) error {
 		req.SetBasicAuth(r.username, r.password)
 	}
 
-	klog.V(4).Infof("POST %q", u)
+	reqID := utils.EncodeSha1(u + filepath)
+	klog.V(4).Infof("[%s] POST %q", reqID, u)
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
@@ -102,11 +98,11 @@ func (r *Repo) Upload(filepath string) error {
 	}
 	defer res.Body.Close()
 
-	// Check status code
-	if res.StatusCode == http.StatusNotFound {
-		errorBody := readErrorBody(res.Body)
-		return errors.Errorf("unable to upload %q chart, got HTTP Status: %s, Resp: %v", filepath, res.Status, errorBody)
+	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
+		bodyStr := utils.HTTPResponseBody(res)
+		return errors.Errorf("unable to fetch index.yaml, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
 	}
+	klog.V(4).Infof("[%s] Got HTTP Status: %s", reqID, res.Status)
 
 	return nil
 }

--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -163,7 +163,7 @@ func (r *Repo) Fetch(filename string, name string, version string) error {
 
 	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
 		bodyStr := utils.HTTPResponseBody(res)
-		return errors.Errorf("unable to fetch %s:%s chart, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
+		return errors.Errorf("unable to fetch %s:%s chart, got HTTP Status: %s, Resp: %v", name, version, res.Status, bodyStr)
 	}
 	klog.V(4).Infof("[%s] Got HTTP Status: %s", reqID, res.Status)
 

--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"strings"
 
 	"github.com/juju/errors"
 	"helm.sh/helm/v3/pkg/repo"

--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -14,13 +14,8 @@ import (
 
 	"github.com/bitnami-labs/charts-syncer/api"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
+	"github.com/bitnami-labs/charts-syncer/pkg/utils"
 )
-
-func readErrorBody(r io.Reader) string {
-	var s strings.Builder
-	_, _ = io.Copy(&s, r)
-	return s.String()
-}
 
 // Repo allows to operate a chart repository.
 type Repo struct {
@@ -43,7 +38,8 @@ var reloadIndex = func(r *Repo) error {
 		req.SetBasicAuth(r.username, r.password)
 	}
 
-	klog.V(4).Infof("GET %q", u)
+	reqID := utils.EncodeSha1(u + "index.yaml")
+	klog.V(4).Infof("[%s] GET %q", reqID, u)
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
@@ -51,11 +47,11 @@ var reloadIndex = func(r *Repo) error {
 	}
 	defer res.Body.Close()
 
-	// Check status code
-	if res.StatusCode == http.StatusNotFound {
-		errorBody := readErrorBody(res.Body)
-		return errors.Errorf("unable to fetch index.yaml, got HTTP Status: %s, Resp: %v", res.Status, errorBody)
+	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
+		bodyStr := utils.HTTPResponseBody(res)
+		return errors.Errorf("unable to fetch index.yaml, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
 	}
+	klog.V(4).Infof("[%s] Got HTTP Status: %s", reqID, res.Status)
 
 	// Create the index.yaml file to use the helm Go library, which does not
 	// expose a Loader from bytes.
@@ -75,7 +71,7 @@ var reloadIndex = func(r *Repo) error {
 
 	index, err := repo.LoadIndexFile(f.Name())
 	if err != nil {
-		return errors.Trace(err)
+		return errors.Annotate(err, "loading index.yaml file")
 	}
 
 	r.index = index
@@ -157,7 +153,8 @@ func (r *Repo) Fetch(filename string, name string, version string) error {
 		req.SetBasicAuth(r.username, r.password)
 	}
 
-	klog.V(4).Infof("GET %q", u)
+	reqID := utils.EncodeSha1(u + filename)
+	klog.V(4).Infof("[%s] GET %q", reqID, u)
 	client := &http.Client{}
 	res, err := client.Do(req)
 	if err != nil {
@@ -165,11 +162,11 @@ func (r *Repo) Fetch(filename string, name string, version string) error {
 	}
 	defer res.Body.Close()
 
-	// Check status code
-	if res.StatusCode == http.StatusNotFound {
-		errorBody := readErrorBody(res.Body)
-		return errors.Errorf("unable to fetch %s:%s chart, got HTTP Status: %s, Resp: %v", name, version, res.Status, errorBody)
+	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
+		bodyStr := utils.HTTPResponseBody(res)
+		return errors.Errorf("unable to fetch %s:%s chart, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
 	}
+	klog.V(4).Infof("[%s] Got HTTP Status: %s", reqID, res.Status)
 
 	// Create the file
 	f, err := os.Create(filename)

--- a/pkg/syncer/index.go
+++ b/pkg/syncer/index.go
@@ -1,7 +1,6 @@
 package syncer
 
 import (
-	"crypto/sha1"
 	"fmt"
 	"path"
 	"sort"
@@ -211,10 +210,4 @@ func (s *Syncer) topologicalSortCharts() ([]*Chart, error) {
 		charts[i] = s.getIndex().Get(id)
 	}
 	return charts, nil
-}
-
-func encodeSha1(s string) string {
-	h := sha1.New()
-	h.Write([]byte(s))
-	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/bitnami-labs/charts-syncer/api"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/core"
+	"github.com/bitnami-labs/charts-syncer/pkg/utils"
 )
 
 // Clients holds the source and target chart repo clients
@@ -120,7 +121,7 @@ func New(source *api.SourceRepo, target *api.TargetRepo, opts ...Option) (*Synce
 	// In order to store charts tgz files in an isolated folder for each chart
 	// repo we are computing a workdir using the hash of the source repo URL
 	// and the pre-configured workdir.
-	s.srcWorkdir = path.Join(s.workdir, encodeSha1(source.GetRepo().GetUrl()))
+	s.srcWorkdir = path.Join(s.workdir, utils.EncodeSha1(source.GetRepo().GetUrl()))
 	if err := os.MkdirAll(s.srcWorkdir, 0755); err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"crypto/sha1"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -8,6 +9,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/bitnami-labs/charts-syncer/api"
@@ -179,4 +181,18 @@ func FileExists(f string) (bool, error) {
 		return false, errors.Trace(err)
 	}
 	return true, nil
+}
+
+// HTTPResponseBody returns the body of an HTTP response
+func HTTPResponseBody(res *http.Response) string {
+	var s strings.Builder
+	_, _ = io.Copy(&s, res.Body)
+	return s.String()
+}
+
+// EncodeSha1 returns a SHA1 representation of the provided string
+func EncodeSha1(s string) string {
+	h := sha1.New()
+	h.Write([]byte(s))
+	return fmt.Sprintf("%x", h.Sum(nil))
 }


### PR DESCRIPTION
The current client implementations are only taking 404 HTTP responses into account. However, we might receive other non-2xx errors.

This patch will make clients take into account all non-2xx responses, instead. It also adds an string identifier to each query log.