### PR TITLE
feat(client): Extend Upload API to accept name and version fields

### DIFF
--- a/pkg/client/chartmuseum/chartmuseum.go
+++ b/pkg/client/chartmuseum/chartmuseum.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/klog"
 
 	"github.com/bitnami-labs/charts-syncer/api"
+	"github.com/bitnami-labs/charts-syncer/internal/utils"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/helmclassic"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
-	"github.com/bitnami-labs/charts-syncer/internal/utils"
 )
 
 // Repo allows to operate a chart repository.
@@ -53,7 +53,7 @@ func (r *Repo) GetUploadURL() string {
 }
 
 // Upload uploads a chart to the repo.
-func (r *Repo) Upload(filepath string) error {
+func (r *Repo) Upload(filepath string, _, _ string) error {
 	body := &bytes.Buffer{}
 	mpw := multipart.NewWriter(body)
 

--- a/pkg/client/core/core.go
+++ b/pkg/client/core/core.go
@@ -4,11 +4,11 @@ import (
 	"github.com/juju/errors"
 
 	"github.com/bitnami-labs/charts-syncer/api"
+	"github.com/bitnami-labs/charts-syncer/internal/utils"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/chartmuseum"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/harbor"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/helmclassic"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
-	"github.com/bitnami-labs/charts-syncer/internal/utils"
 )
 
 // Reader defines the methods that a ReadOnly chart client should implement.
@@ -25,7 +25,7 @@ type Reader interface {
 
 // Writer defines the methods that a WriteOnly chart client should implement.
 type Writer interface {
-	Upload(filepath string) error
+	Upload(filepath string, name string, version string) error
 }
 
 // ValidateChartTgz validates if a chart is a valid tgz file

--- a/pkg/client/harbor/harbor.go
+++ b/pkg/client/harbor/harbor.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/klog"
 
 	"github.com/bitnami-labs/charts-syncer/api"
+	"github.com/bitnami-labs/charts-syncer/internal/utils"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/helmclassic"
 	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
-	"github.com/bitnami-labs/charts-syncer/internal/utils"
 )
 
 // Repo allows to operate a chart repository.
@@ -54,7 +54,7 @@ func (r *Repo) GetUploadURL() string {
 }
 
 // Upload uploads a chart to the repo
-func (r *Repo) Upload(filepath string) error {
+func (r *Repo) Upload(filepath string, _, _ string) error {
 	body := &bytes.Buffer{}
 	mpw := multipart.NewWriter(body)
 

--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -12,8 +12,8 @@ import (
 	"k8s.io/klog"
 
 	"github.com/bitnami-labs/charts-syncer/api"
-	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
 	"github.com/bitnami-labs/charts-syncer/internal/utils"
+	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
 )
 
 // Repo allows to operate a chart repository.
@@ -198,7 +198,7 @@ func (r *Repo) Has(name string, version string) (bool, error) {
 }
 
 // Upload uploads a chart to the repo
-func (r *Repo) Upload(filepath string) error {
+func (r *Repo) Upload(filepath string, _, _ string) error {
 	return errors.Errorf("upload method is not supported yet")
 }
 

--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -10,9 +10,9 @@ import (
 	"k8s.io/klog"
 
 	"github.com/bitnami-labs/charts-syncer/internal/chart"
-	"github.com/bitnami-labs/charts-syncer/pkg/client/core"
 	"github.com/bitnami-labs/charts-syncer/internal/helmcli"
 	"github.com/bitnami-labs/charts-syncer/internal/utils"
+	"github.com/bitnami-labs/charts-syncer/pkg/client/core"
 )
 
 // Sync synchronizes source and target chart repos
@@ -158,7 +158,7 @@ func (s *Syncer) SyncPendingCharts(names ...string) error {
 		}
 
 		klog.V(3).Infof("Uploading %q chart...", id)
-		if err := s.cli.dst.Upload(tgz); err != nil {
+		if err := s.cli.dst.Upload(tgz, ch.Name, ch.Version); err != nil {
 			klog.Errorf("unable to upload %q chart: %+v", id, err)
 			errs = multierror.Append(errs, errors.Trace(err))
 			continue


### PR DESCRIPTION
Both #67 and #70 require an extended version of `Upload` that accepts `name` and `version` chart values.