### PR TITLE
feat(ci): Set up publishing to bitnami-labs registry

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,6 +14,12 @@ jobs:
         uses: actions/checkout@v2
       - name: Unshallow
         run: git fetch --prune --unshallow
+      - name: Docker login to GCR
+        uses: docker/login-action@v1
+        with:
+          registry: gcr.io
+          username: _json_key
+          password: ${{ secrets.GCR_JSON_KEY }}
       - name: Set up Go
         uses: actions/setup-go@v1
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,9 +19,9 @@ jobs:
         with:
           go-version: 1.14.x
       - name: Release
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist
+          args: release --rm-dist --skip-publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,6 +22,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --rm-dist --skip-publish
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,17 @@ builds:
       - GO111MODULE=on
     main: ./main.go
     binary: charts-syncer
+dockers:
+  dockerfile: Dockerfile
+  binaries:
+    - charts-syncer
+  images_templates:
+    - "gcr.io/bitnami-images/charts-syncer:{{ .Version }}"
+    - "gcr.io/bitnami-images/charts-syncer:lastest"
+  build_flag_templates:
+  - "--build-arg"
+  - "IMAGE_VERSION={{ .Version }}"
+  skip_push: true
 archives:
   - replacements:
       386: i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -16,11 +16,11 @@ dockers:
       - charts-syncer
     dockerfile: Dockerfile
     image_templates:
-      - "gcr.io/bitnami-images/charts-syncer:{{ .Version }}"
-      - "gcr.io/bitnami-images/charts-syncer:latest"
+      - "gcr.io/bitnami-labs/charts-syncer:{{ .Tag }}"
+      - "gcr.io/bitnami-labs/charts-syncer:latest"
     build_flag_templates:
       - "--build-arg"
-      - "IMAGE_VERSION={{ .Version }}"
+      - "IMAGE_VERSION={{ .Tag }}"
 archives:
   - replacements:
       386: i386

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,16 +9,18 @@ builds:
     main: ./main.go
     binary: charts-syncer
 dockers:
-  dockerfile: Dockerfile
-  binaries:
-    - charts-syncer
-  images_templates:
-    - "gcr.io/bitnami-images/charts-syncer:{{ .Version }}"
-    - "gcr.io/bitnami-images/charts-syncer:lastest"
-  build_flag_templates:
-  - "--build-arg"
-  - "IMAGE_VERSION={{ .Version }}"
-  skip_push: true
+  -
+    builds:
+      - release
+    binaries:
+      - charts-syncer
+    dockerfile: Dockerfile
+    image_templates:
+      - "gcr.io/bitnami-images/charts-syncer:{{ .Version }}"
+      - "gcr.io/bitnami-images/charts-syncer:latest"
+    build_flag_templates:
+      - "--build-arg"
+      - "IMAGE_VERSION={{ .Version }}"
 archives:
   - replacements:
       386: i386

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM bitnami/minideb:buster
+ARG IMAGE_VERSION
+ENV IMAGE_VERSION=${IMAGE_VERSION}
 
 RUN install_packages ca-certificates curl && \
     curl -sL "https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz" | tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm && \
     chmod +x /usr/local/bin/helm
 
 COPY ./dist/charts-syncer /
+RUN chmod +x /charts-syncer
 
-ENV IMAGE_VERSION="0.0.1-r0"
-ENTRYPOINT ["/charts-syncer"]
+CMD [ "/charts-syncer" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,5 @@ RUN install_packages ca-certificates curl && \
     curl -sL "https://get.helm.sh/helm-v3.2.1-linux-amd64.tar.gz" | tar -xz --strip-components=1 -C /usr/local/bin linux-amd64/helm && \
     chmod +x /usr/local/bin/helm
 
-COPY ./dist/charts-syncer /
-RUN chmod +x /charts-syncer
-
+COPY ./charts-syncer /
 CMD [ "/charts-syncer" ]


### PR DESCRIPTION
This PR includes changes to be able to publish a new version of `charts-syncer` to gcr.io/bitnami-labs on each release.

Changes included:

- Added `dockers` section to `goreleaser.yml` and sets up necessary configuration. It will push two images, one with the `latest` tag and another one with the actual version.
- Updated `Dockerfile` to be able to install additional dependencies needed by `charts-syncer`.
- Updated version of goreleaser to v2.
- Added a new docker-login action to be able to authenticate to gcr.io.
- Added `GCR_JSON_KEY` to GitHub repository's secrets.