### PR TITLE
feat(syncer): Add SyncPendingCharts tests

### DIFF
--- a/pkg/syncer/index_internal_test.go
+++ b/pkg/syncer/index_internal_test.go
@@ -15,15 +15,12 @@ func removeTgzPath(i ChartIndex) {
 func TestLoadCharts(t *testing.T) {
 	testCases := []struct {
 		desc    string
-		entries map[string][]string
+		entries []string
 		want    ChartIndex
 	}{
 		{
-			desc: "load apache and kafka",
-			entries: map[string][]string{
-				"apache": {"7.3.15"},
-				"kafka":  {"10.3.3"},
-			},
+			desc:    "load apache and kafka",
+			entries: []string{"apache", "kafka"},
 			want: ChartIndex{
 				"apache-7.3.15":    &Chart{Name: "apache", Version: "7.3.15"},
 				"kafka-10.3.3":     &Chart{Name: "kafka", Version: "10.3.3", Dependencies: []string{"zookeeper-5.14.3"}},
@@ -34,12 +31,8 @@ func TestLoadCharts(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			s := NewFake(t, tc.entries)
-			var charts []string
-			for name := range tc.entries {
-				charts = append(charts, name)
-			}
-			if err := s.loadCharts(charts...); err != nil {
+			s := NewFake(t)
+			if err := s.loadCharts(tc.entries...); err != nil {
 				t.Fatalf("unable to load charts: %v", err)
 			}
 

--- a/pkg/syncer/sync_test.go
+++ b/pkg/syncer/sync_test.go
@@ -1,38 +1,60 @@
 package syncer_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
 	"testing"
+
+	"github.com/bitnami-labs/charts-syncer/pkg/syncer"
 )
 
 func TestSyncPendingCharts(t *testing.T) {
 	testCases := []struct {
 		desc    string
-		entries map[string][]string
-		charts  []string
+		entries []string
+		want    []string
 	}{
 		{
-			desc: "load apache and kafka",
-			entries: map[string][]string{
-				"apache": {"7.3.15"},
-				"kafka":  {"10.3.3"},
-			},
-			charts: []string{"apache", "kafka"},
+			desc:    "load apache and kafka",
+			entries: []string{"apache", "kafka"},
+			want:    []string{"apache-7.3.15.tgz", "kafka-10.3.3.tgz", "zookeeper-5.14.3.tgz"},
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
-			// TODO(jdrios): We can't invoke SyncPendingCharts since this function
-			// tries to add the target repo using the helm cli.
+			dstTmp, err := ioutil.TempDir("", "charts-syncer-tests-dst-fake")
+			if err != nil {
+				t.Fatalf("error creating temporary folder: %v", err)
+			}
+			defer os.RemoveAll(dstTmp)
 
-			// s := syncer.NewFake(t, tc.entries)
-			// var charts []string
-			// for name := range tc.entries {
-			// 	charts = append(charts, name)
-			// }
-			// if err := s.SyncPendingCharts(charts...); err != nil {
-			// 	t.Error(err)
-			// }
+			s := syncer.NewFake(t, syncer.WithFakeSyncerDestination(dstTmp))
+
+			if err := s.SyncPendingCharts(tc.entries...); err != nil {
+				t.Error(err)
+			}
+
+			// We could use the fake client to obtain the list of synced charts.
+			// However, as it is a fake implementation, let's rely on the target
+			// directory.
+			// If we change the implementation to be in-memory, this won't work.
+			gotFiles, err := filepath.Glob(fmt.Sprintf("%s/*.tgz", dstTmp))
+			if err != nil {
+				t.Fatalf("error listing tgz files: %v", err)
+			}
+
+			var got []string
+			for _, file := range gotFiles {
+				got = append(got, filepath.Base(file))
+			}
+
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("got: %v, want: %v\n", got, tc.want)
+			}
 		})
 	}
 }


### PR DESCRIPTION
This PR uses the fake (local-impl) client feature to add tests for the `SyncPendingCharts` functionality, which is the core of this tool.