### PR TITLE
test: improve Untar unit tests

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -103,8 +103,6 @@ func downloadIndex(repo *api.Repo) (string, error) {
 }
 
 // Untar extracts compressed archives
-//
-// Based on Extract function from helm plugin installer. https://github.com/helm/helm/blob/master/pkg/plugin/installer/http_installer.go
 func Untar(tarball, targetDir string) error {
 	if err := os.MkdirAll(targetDir, 0755); err != nil {
 		return err

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -70,8 +70,26 @@ func TestUntar(t *testing.T) {
 	if err := Untar(filepath, testTmpDir); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := os.Stat(path.Join(testTmpDir, "apache/Chart.yaml")); err != nil {
-		t.Error("error untaring chart package")
+	tarFiles := []string{
+		"apache/Chart.yaml",
+		"apache/values.yaml",
+		"apache/templates/NOTES.txt",
+		"apache/templates/_helpers.tpl",
+		"apache/templates/configmap-vhosts.yaml",
+		"apache/templates/configmap.yaml",
+		"apache/templates/deployment.yaml",
+		"apache/templates/ingress.yaml",
+		"apache/templates/svc.yaml",
+		"apache/.helmignore",
+		"apache/README.md",
+		"apache/files/README.md",
+		"apache/files/vhosts/README.md",
+		"apache/values.schema.json",
+	}
+	for _, f := range tarFiles {
+		if _, err := os.Stat(path.Join(testTmpDir, f)); err != nil {
+			t.Errorf("error untaring chart package. %q not found", f)
+		}
 	}
 }
 


### PR DESCRIPTION
This PR just improves a bit the Untar unit tests so we also check that files from subfolders in the tarball are properly uncompressed.