### PR TITLE
feat: use from scratch in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
+FROM bitnami/minideb:buster as build
+RUN install_packages ca-certificates
+RUN mkdir /workdir
+
 FROM scratch
 ARG IMAGE_VERSION
 ENV IMAGE_VERSION=${IMAGE_VERSION}
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /workdir /tmp
 COPY ./charts-syncer /
-CMD [ "/charts-syncer" ]
+ENTRYPOINT [ "/charts-syncer" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM scratch
 ARG IMAGE_VERSION
 ENV IMAGE_VERSION=${IMAGE_VERSION}
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+# Workaround to have a /tmp folder in the scratch container
 COPY --from=build /workdir /tmp
 COPY ./charts-syncer /
 ENTRYPOINT [ "/charts-syncer" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/minideb:buster
+FROM scratch
 ARG IMAGE_VERSION
 ENV IMAGE_VERSION=${IMAGE_VERSION}
 COPY ./charts-syncer /

--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ gen:
 	go generate github.com/bitnami-labs/charts-syncer/...
 
 build: $(GO_SOURCES)
-	GO111MODULE=on go build -o $(OUTPUT) ./
+	GO111MODULE=on CGO_ENABLED=0 go build -o $(OUTPUT) ./


### PR DESCRIPTION
After removing external helm cli and tar dependencies in #84 and #85 we can simply use a scratch container