### PR TITLE
test(helmclassic): Add unit tests for helmclassic client

### DIFF
--- a/pkg/client/helmclassic/helmclassic.go
+++ b/pkg/client/helmclassic/helmclassic.go
@@ -26,7 +26,7 @@ type Repo struct {
 	password string
 
 	// NOTE: We need a lock for index to allow concurrency
-	index *repo.IndexFile
+	Index *repo.IndexFile
 
 	cache cache.Cacher
 }
@@ -78,7 +78,7 @@ var reloadIndex = func(r *Repo) error {
 		return errors.Annotate(err, "loading index.yaml file")
 	}
 
-	r.index = index
+	r.Index = index
 	return nil
 }
 
@@ -105,7 +105,7 @@ func NewRaw(u *url.URL, user string, pass string, c cache.Cacher) (*Repo, error)
 
 // GetDownloadURL returns the URL to download a chart
 func (r *Repo) GetDownloadURL(n string, v string) (string, error) {
-	chart, err := r.index.Get(n, v)
+	chart, err := r.Index.Get(n, v)
 	if err != nil {
 		return "", errors.Annotatef(err, "getting %s-%s from index file", n, v)
 	}
@@ -122,7 +122,7 @@ func (r *Repo) GetIndexURL() string {
 // List lists all chart names in a repo
 func (r *Repo) List() ([]string, error) {
 	var names []string
-	for name := range r.index.Entries {
+	for name := range r.Index.Entries {
 		names = append(names, name)
 	}
 
@@ -131,7 +131,7 @@ func (r *Repo) List() ([]string, error) {
 
 // ListChartVersions lists all versions of a chart
 func (r *Repo) ListChartVersions(name string) ([]string, error) {
-	cv, ok := r.index.Entries[name]
+	cv, ok := r.Index.Entries[name]
 	if !ok {
 		return []string{}, nil
 	}
@@ -212,7 +212,7 @@ func (r *Repo) Upload(_ string, _ *chart.Metadata) error {
 
 // GetChartDetails returns the details of a chart
 func (r *Repo) GetChartDetails(name string, version string) (*types.ChartDetails, error) {
-	cv, err := r.index.Get(name, version)
+	cv, err := r.Index.Get(name, version)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/pkg/client/helmclassic/helmclassic_test.go
+++ b/pkg/client/helmclassic/helmclassic_test.go
@@ -1,0 +1,219 @@
+package helmclassic
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/bitnami-labs/charts-syncer/api"
+	"github.com/bitnami-labs/charts-syncer/internal/cache"
+	"github.com/bitnami-labs/charts-syncer/internal/utils"
+	"github.com/bitnami-labs/charts-syncer/pkg/client/types"
+	"helm.sh/helm/v3/pkg/time"
+)
+
+var (
+	cmRepo = &api.Repo{
+		Kind: api.Kind_CHARTMUSEUM,
+		Auth: &api.Auth{
+			Username: "user",
+			Password: "password",
+		},
+	}
+)
+
+func prepareTest(t *testing.T) (*Repo, error) {
+	t.Helper()
+
+	// Create temp folder and copy index.yaml
+	dstTmp, err := ioutil.TempDir("", "charts-syncer-tests-index-fake")
+	if err != nil {
+		t.Fatalf("error creating temporary folder: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dstTmp) })
+	dstIndex := filepath.Join(dstTmp, "index.yaml")
+	if err := utils.CopyFile(dstIndex, "../../../testdata/index.yaml"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create tester
+	tester, cleanup, err := NewTester(t, cmRepo, false, dstIndex)
+	t.Cleanup(func() { cleanup() })
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmRepo.Url = tester.GetURL()
+
+	// Replace placeholder
+	u := fmt.Sprintf("%s%s", tester.GetURL(), "/charts")
+	index, err := ioutil.ReadFile(dstIndex)
+	if err != nil {
+		t.Fatal(err)
+	}
+	newContents := strings.Replace(string(index), "TEST_PLACEHOLDER", u, -1)
+	if err = ioutil.WriteFile(dstIndex, []byte(newContents), 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// Define cache dir
+	cacheDir, err := ioutil.TempDir("", "client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cache, err := cache.New(cacheDir, cmRepo.GetUrl())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create chartmuseum client
+	client, err := New(cmRepo, cache)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client, nil
+}
+
+func TestFetch(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chartPath, err := c.Fetch("etcd", "4.8.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(chartPath); err != nil {
+		t.Errorf("chart package does not exist")
+	}
+}
+
+func TestHas(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	has, err := c.Has("etcd", "4.8.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !has {
+		t.Errorf("chart not found in index")
+	}
+}
+
+func TestList(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"common", "etcd", "nginx"}
+	got, err := c.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(want)
+	sort.Strings(got)
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("unexpected list of charts. got: %v, want: %v", got, want)
+	}
+}
+
+func TestListChartVersions(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"4.8.0", "4.7.4", "4.7.3", "4.7.2", "4.7.1", "4.7.0"}
+	got, err := c.ListChartVersions("etcd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(want)
+	sort.Strings(got)
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("unexpected list of charts. got: %v, want: %v", got, want)
+	}
+}
+
+func TestGetChartDetails(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := types.ChartDetails{
+		PublishedAt: time.Now().Time,
+		Digest:      "d47d94c52aff1fbb92235f0753c691072db1d19ec43fa9a438ab6736dfa7f867",
+	}
+	got, err := c.GetChartDetails("etcd", "4.8.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want.Digest != got.Digest {
+		t.Errorf("unexpected digest in chart. got: %v, want: %v", got, want)
+	}
+}
+
+func TestReload(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := c.Reload(); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"common", "etcd", "nginx"}
+	indexFile := c.Index
+	got := []string{}
+	for chart := range indexFile.Entries {
+		got = append(got, chart)
+	}
+	sort.Strings(want)
+	sort.Strings(got)
+	if !reflect.DeepEqual(want, got) {
+		t.Errorf("unexpected list of charts. got: %v, want: %v", got, want)
+	}
+}
+
+func TestGetDownloadURL(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := fmt.Sprintf("%s%s", cmRepo.Url, "/charts/etcd-4.8.0.tgz")
+	got, err := c.GetDownloadURL("etcd", "4.8.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Errorf("wrong download URL. got: %v, want: %v", got, want)
+	}
+}
+
+func TestGetIndexURL(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := fmt.Sprintf("%s%s", cmRepo.Url, "/index.yaml")
+	got := c.GetIndexURL()
+	if got != want {
+		t.Errorf("wrong index URL. got: %v, want: %v", got, want)
+	}
+}
+
+func TestUpload(t *testing.T) {
+	c, err := prepareTest(t)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedError := "upload method is not supported yet"
+	err = c.Upload("../../../testdata/apache-7.3.15.tgz", nil)
+	if err.Error() != expectedError {
+		t.Errorf("unexpected error message. got: %q, want: %q", err.Error(), expectedError)
+	}
+}

--- a/pkg/client/helmclassic/helmclassictester.go
+++ b/pkg/client/helmclassic/helmclassictester.go
@@ -1,0 +1,234 @@
+package helmclassic
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/bitnami-labs/charts-syncer/api"
+	"github.com/juju/errors"
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	cmRegex         = regexp.MustCompile(`(?m)\/charts\/(.*.tgz)`)
+	username string = "user"
+	password string = "password"
+)
+
+// Metadata in Chart.yaml files
+type Metadata struct {
+	AppVersion string `json:"appVersion"`
+	Name       string `json:"name"`
+	Version    string `json:"version"`
+}
+
+// ChartVersion type
+type ChartVersion struct {
+	Name    string   `json:"name"`
+	Version string   `json:"version"`
+	URLs    []string `json:"urls"`
+}
+
+type httpError struct {
+	status int
+	body   string
+}
+
+// RepoTester allows to unit test each repo implementation
+type RepoTester struct {
+	url      *url.URL
+	username string
+	password string
+	t        *testing.T
+	// Map of chart name to indexed versions, as returned by the charts API.
+	index map[string][]*ChartVersion
+
+	// Whether the repo should load an empty index or not
+	emptyIndex bool
+
+	// index.yaml to be loaded for testing purposes
+	indexFile string
+	// Set to simulate HTTP error responses for specific API calls.
+	ChartsPostError *httpError
+}
+
+// NewTester creates fake HTTP server to handle requests and return a RepoTester object with useful info for testing
+func NewTester(t *testing.T, repo *api.Repo, emptyIndex bool, indexFile string) (*RepoTester, func(), error) {
+	tester := &RepoTester{
+		t:          t,
+		username:   username,
+		password:   password,
+		emptyIndex: emptyIndex,
+		indexFile:  indexFile,
+		index:      make(map[string][]*ChartVersion),
+	}
+	s := httptest.NewServer(tester)
+	u, err := url.Parse(s.URL)
+	if err != nil {
+		return nil, s.Close, errors.Trace(err)
+	}
+	tester.url = u
+	return tester, s.Close, nil
+}
+
+// ServeHTTP implements the the http Handler type
+func (rt *RepoTester) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	// Check basic auth credentals.
+	username, password, ok := r.BasicAuth()
+	if got, want := ok, true; got != want {
+		rt.t.Errorf("got: %t, want: %t", got, want)
+	}
+	if got, want := username, rt.username; got != want {
+		rt.t.Errorf("got: %q, want: %q", got, want)
+	}
+	if got, want := password, rt.password; got != want {
+		rt.t.Errorf("got: %q, want: %q", got, want)
+	}
+
+	// Handle recognized requests.
+	if base, chart := path.Split(r.URL.Path); base == "/api/charts/" && r.Method == "GET" {
+		rt.GetChart(w, r, chart)
+		return
+	}
+	if r.URL.Path == "/api/charts" && r.Method == "POST" {
+		rt.PostChart(w, r)
+		return
+	}
+	if r.URL.Path == "/index.yaml" && r.Method == "GET" {
+		rt.GetIndex(w, r, rt.emptyIndex, rt.indexFile)
+		return
+	}
+	if cmRegex.Match([]byte(r.URL.Path)) && r.Method == "GET" {
+		chartPackage := strings.Split(r.URL.Path, "/")[2]
+		rt.GetChartPackage(w, r, chartPackage)
+		return
+	}
+
+	rt.t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+
+}
+
+// GetChart returns the chart info from the index
+func (rt *RepoTester) GetChart(w http.ResponseWriter, r *http.Request, chart string) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(rt.index[chart]); err != nil {
+		rt.t.Fatal(err)
+	}
+
+}
+
+// GetURL returns the URL of the server
+func (rt *RepoTester) GetURL() string {
+	return rt.url.String()
+}
+
+// GetIndex returns an index file
+func (rt *RepoTester) GetIndex(w http.ResponseWriter, r *http.Request, emptyIndex bool, indexFile string) {
+	w.Header().Set("Content-Type", "application/yaml")
+	w.WriteHeader(200)
+	_, filename, _, _ := runtime.Caller(1)
+	testdataPath := path.Join(path.Dir(filename), "../../../testdata")
+	// Get index from testdata folder
+	if indexFile == "" {
+		indexFile = filepath.Join(testdataPath, "index.yaml")
+	}
+	if emptyIndex {
+		indexFile = filepath.Join(testdataPath, "empty-index.yaml")
+	}
+	index, err := ioutil.ReadFile(indexFile)
+	if err != nil {
+		rt.t.Fatal(err)
+	}
+	w.Write(index)
+
+}
+
+// GetChartPackage returns a packaged helm chart
+func (rt *RepoTester) GetChartPackage(w http.ResponseWriter, r *http.Request, chartPackageName string) {
+	w.WriteHeader(200)
+	_, filename, _, _ := runtime.Caller(1)
+	testdataPath := path.Join(path.Dir(filename), "../../../testdata")
+	// Get chart from testdata folder
+	chartPackageFile := path.Join(testdataPath, "charts", chartPackageName)
+	chartPackage, err := ioutil.ReadFile(chartPackageFile)
+	if err != nil {
+		rt.t.Fatal(err)
+	}
+	w.Write(chartPackage)
+
+}
+
+// PostChart push a packaged chart
+func (rt *RepoTester) PostChart(w http.ResponseWriter, r *http.Request) {
+	if rt.ChartsPostError != nil {
+		w.WriteHeader(rt.ChartsPostError.status)
+		w.Write([]byte(rt.ChartsPostError.body))
+		return
+	}
+
+	chartFile, _, err := r.FormFile("chart")
+	if err != nil {
+		rt.t.Fatal(err)
+	}
+
+	metadata, err := chartMetadataFromTGZ(chartFile)
+	if err != nil {
+		rt.t.Fatal(err)
+	}
+
+	rt.index[metadata.Name] = append(rt.index[metadata.Name], &ChartVersion{
+		Name:    metadata.Name,
+		Version: metadata.Version,
+		URLs:    []string{fmt.Sprintf("charts/%s-%s.tgz", metadata.Name, metadata.Version)},
+	})
+
+	w.WriteHeader(201)
+	w.Write([]byte(`{}`))
+
+}
+
+func chartMetadataFromTGZ(r io.Reader) (*Metadata, error) {
+	const (
+		metadataFile = "Chart.yaml"
+	)
+
+	gz, err := gzip.NewReader(r)
+	if err != nil {
+		return nil, err
+	}
+	t := tar.NewReader(gz)
+
+	// Iterate over tar until the metadata file
+	for {
+		h, err := t.Next()
+		if err != nil {
+			return nil, err
+		}
+		// A tgz may contain multiple Chart.yaml files - the main chart and its
+		// subcharts - but assume there are no subcharts for now.
+		_, file := filepath.Split(h.Name)
+		if file == metadataFile {
+			break
+		}
+	}
+
+	data, err := ioutil.ReadAll(t)
+	if err != nil {
+		return nil, err
+	}
+	m := &Metadata{}
+	return m, yaml.Unmarshal(data, m)
+}

--- a/testdata/index.yaml
+++ b/testdata/index.yaml
@@ -22,7 +22,7 @@ entries:
     sources:
     - https://github.com/bitnami/charts
     urls:
-    - https://fake.chart.repo.com/testing/common-0.2.1.tgz
+    - TEST_PLACEHOLDER/common-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v1
     appVersion: 0.1.0
@@ -45,7 +45,7 @@ entries:
     sources:
     - https://github.com/bitnami/charts
     urls:
-    - https://fake.chart.repo.com/testing/common-0.2.0.tgz
+    - TEST_PLACEHOLDER/common-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v1
     appVersion: 0.1.0
@@ -68,7 +68,7 @@ entries:
     sources:
     - https://github.com/bitnami/charts
     urls:
-    - https://fake.chart.repo.com/testing/common-0.1.1.tgz
+    - TEST_PLACEHOLDER/common-0.1.1.tgz
     version: 0.1.1
   etcd:
   - apiVersion: v1
@@ -93,7 +93,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-etcd
     urls:
-    - https://fake.chart.repo.com/testing/etcd-4.8.0.tgz
+    - TEST_PLACEHOLDER/etcd-4.8.0.tgz
     version: 4.8.0
   - apiVersion: v1
     appVersion: 3.4.7
@@ -117,7 +117,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-etcd
     urls:
-    - https://fake.chart.repo.com/testing/etcd-4.7.4.tgz
+    - TEST_PLACEHOLDER/etcd-4.7.4.tgz
     version: 4.7.4
   - apiVersion: v1
     appVersion: 3.4.7
@@ -141,7 +141,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-etcd
     urls:
-    - https://fake.chart.repo.com/testing/etcd-4.7.3.tgz
+    - TEST_PLACEHOLDER/etcd-4.7.3.tgz
     version: 4.7.3
   - apiVersion: v1
     appVersion: 3.4.7
@@ -165,7 +165,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-etcd
     urls:
-    - https://fake.chart.repo.com/testing/etcd-4.7.2.tgz
+    - TEST_PLACEHOLDER/etcd-4.7.2.tgz
     version: 4.7.2
   - apiVersion: v1
     appVersion: 3.4.6
@@ -189,7 +189,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-etcd
     urls:
-    - https://fake.chart.repo.com/testing/etcd-4.7.1.tgz
+    - TEST_PLACEHOLDER/etcd-4.7.1.tgz
     version: 4.7.1
   - apiVersion: v1
     appVersion: 3.4.5
@@ -213,7 +213,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-etcd
     urls:
-    - https://fake.chart.repo.com/testing/etcd-4.7.0.tgz
+    - TEST_PLACEHOLDER/etcd-4.7.0.tgz
     version: 4.7.0
   nginx:
   - apiVersion: v1
@@ -237,7 +237,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-nginx
     urls:
-    - https://fake.chart.repo.com/testing/nginx-5.3.0.tgz
+    - TEST_PLACEHOLDER/nginx-5.3.0.tgz
     version: 5.3.0
   - apiVersion: v1
     appVersion: 1.17.10
@@ -260,7 +260,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-nginx
     urls:
-    - https://fake.chart.repo.com/testing/nginx-5.2.1.tgz
+    - TEST_PLACEHOLDER/nginx-5.2.1.tgz
     version: 5.2.1
   - apiVersion: v1
     appVersion: 1.16.1
@@ -283,7 +283,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-nginx
     urls:
-    - https://fake.chart.repo.com/testing/nginx-5.2.0.tgz
+    - TEST_PLACEHOLDER/nginx-5.2.0.tgz
     version: 5.2.0
   - apiVersion: v1
     appVersion: 1.16.1
@@ -306,7 +306,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-nginx
     urls:
-    - https://fake.chart.repo.com/testing/nginx-5.1.3.tgz
+    - TEST_PLACEHOLDER/nginx-5.1.3.tgz
     version: 5.1.3
   - apiVersion: v1
     appVersion: 1.16.1
@@ -329,7 +329,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-nginx
     urls:
-    - https://fake.chart.repo.com/testing/nginx-5.1.2.tgz
+    - TEST_PLACEHOLDER/nginx-5.1.2.tgz
     version: 5.1.2
   - apiVersion: v1
     appVersion: 1.16.1
@@ -352,7 +352,7 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-nginx
     urls:
-    - https://fake.chart.repo.com/testing/nginx-5.1.1.tgz
+    - TEST_PLACEHOLDER/nginx-5.1.1.tgz
     version: 5.1.1
   - apiVersion: v1
     appVersion: 1.16.1
@@ -375,6 +375,6 @@ entries:
     sources:
     - https://github.com/bitnami/bitnami-docker-nginx
     urls:
-    - https://fake.chart.repo.com/testing/nginx-5.1.0.tgz
+    - TEST_PLACEHOLDER/nginx-5.1.0.tgz
     version: 5.1.0
 generated: "2020-05-13T12:45:29.902443152Z"


### PR DESCRIPTION
This PR adds unit tests for Helmclassic implementation.

There is duplicated code from #90, so I plan to refactor/rebase those chartmuseum tests after helm one has been merged. 