### PR TITLE
feat: add insecure flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,8 +15,9 @@ var (
 
 Find more information at: https://github.com/bitnami-labs/charts-syncer`
 
-	rootConfig string
-	rootDryRun bool
+	rootConfig   string
+	rootDryRun   bool
+	rootInsecure bool
 )
 
 func newRootCmd() *cobra.Command {
@@ -30,6 +31,7 @@ func newRootCmd() *cobra.Command {
 
 	cmd.PersistentFlags().BoolVar(&rootDryRun, "dry-run", false, "Only shows the charts pending to be synced without syncing them")
 	cmd.PersistentFlags().StringVarP(&rootConfig, "config", "c", "", fmt.Sprintf("Config file. Defaults to ./%s or $HOME/%s)", defaultCfgFile, defaultCfgFile))
+	cmd.PersistentFlags().BoolVar(&rootInsecure, "insecure", false, "Allow insecure SSL connections")
 
 	// Add subcommands
 	cmd.AddCommand(

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -15,7 +15,6 @@ import (
 var (
 	syncFromDate string
 	syncWorkdir  string
-	insecure     bool
 )
 
 var (
@@ -78,7 +77,7 @@ func newSyncCmd() *cobra.Command {
 				syncer.WithDryRun(rootDryRun),
 				syncer.WithFromDate(syncFromDate),
 				syncer.WithWorkdir(syncWorkdir),
-				syncer.WithInsecure(insecure),
+				syncer.WithInsecure(rootInsecure),
 			)
 			if err != nil {
 				return errors.Trace(err)
@@ -90,7 +89,6 @@ func newSyncCmd() *cobra.Command {
 
 	cmd.Flags().StringVar(&syncFromDate, "from-date", "", "Date you want to synchronize charts from. Format: YYYY-MM-DD")
 	cmd.Flags().StringVar(&syncWorkdir, "workdir", syncer.DefaultWorkdir(), "Working directory")
-	cmd.Flags().BoolVarP(&insecure, "insecure", "", false, "Allow insecure SSL connections")
 
 	return cmd
 }

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -15,6 +15,7 @@ import (
 var (
 	syncFromDate string
 	syncWorkdir  string
+	insecure     bool
 )
 
 var (
@@ -77,6 +78,7 @@ func newSyncCmd() *cobra.Command {
 				syncer.WithDryRun(rootDryRun),
 				syncer.WithFromDate(syncFromDate),
 				syncer.WithWorkdir(syncWorkdir),
+				syncer.WithInsecure(insecure),
 			)
 			if err != nil {
 				return errors.Trace(err)
@@ -87,7 +89,8 @@ func newSyncCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&syncFromDate, "from-date", "", "Date you want to synchronize charts from. Format: YYYY-MM-DD")
-	cmd.Flags().StringVar(&syncWorkdir, "workdir", syncer.DefaultWorkdir(), "Working directory.")
+	cmd.Flags().StringVar(&syncWorkdir, "workdir", syncer.DefaultWorkdir(), "Working directory")
+	cmd.Flags().BoolVarP(&insecure, "insecure", "", false, "Allow insecure SSL connections")
 
 	return cmd
 }

--- a/pkg/client/chartmuseum/chartmuseum_test.go
+++ b/pkg/client/chartmuseum/chartmuseum_test.go
@@ -71,7 +71,7 @@ func prepareTest(t *testing.T) (*chartmuseum.Repo, error) {
 	}
 
 	// Create chartmuseum client
-	client, err := chartmuseum.New(cmRepo, cache)
+	client, err := chartmuseum.New(cmRepo, cache, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/core/core.go
+++ b/pkg/client/core/core.go
@@ -62,6 +62,7 @@ var NewClient = func(repo *api.Repo, opts ...types.Option) (Client, error) {
 		o(copts)
 	}
 
+	insecure := copts.GetInsecure()
 	// Define cache dir if it hasn't been provided
 	cacheDir := copts.GetCache()
 	if cacheDir == "" {
@@ -78,13 +79,13 @@ var NewClient = func(repo *api.Repo, opts ...types.Option) (Client, error) {
 
 	switch repo.Kind {
 	case api.Kind_HELM:
-		return helmclassic.New(repo, c)
+		return helmclassic.New(repo, c, insecure)
 	case api.Kind_CHARTMUSEUM:
-		return chartmuseum.New(repo, c)
+		return chartmuseum.New(repo, c, insecure)
 	case api.Kind_HARBOR:
-		return harbor.New(repo, c)
+		return harbor.New(repo, c, insecure)
 	case api.Kind_OCI:
-		return oci.New(repo, c)
+		return oci.New(repo, c, insecure)
 	case api.Kind_LOCAL:
 		return local.New(repo.Path)
 	default:

--- a/pkg/client/harbor/harbor.go
+++ b/pkg/client/harbor/harbor.go
@@ -2,6 +2,7 @@ package harbor
 
 import (
 	"bytes"
+	"crypto/tls"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -26,6 +27,7 @@ type Repo struct {
 	url      *url.URL
 	username string
 	password string
+	insecure bool
 
 	helm *helmclassic.Repo
 
@@ -33,23 +35,23 @@ type Repo struct {
 }
 
 // New creates a Repo object from an api.Repo object.
-func New(repo *api.Repo, c cache.Cacher) (*Repo, error) {
+func New(repo *api.Repo, c cache.Cacher, insecure bool) (*Repo, error) {
 	u, err := url.Parse(repo.GetUrl())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	return NewRaw(u, repo.GetAuth().GetUsername(), repo.GetAuth().GetPassword(), c)
+	return NewRaw(u, repo.GetAuth().GetUsername(), repo.GetAuth().GetPassword(), c, insecure)
 }
 
 // NewRaw creates a Repo object.
-func NewRaw(u *url.URL, user string, pass string, c cache.Cacher) (*Repo, error) {
-	helm, err := helmclassic.NewRaw(u, user, pass, c)
+func NewRaw(u *url.URL, user string, pass string, c cache.Cacher, insecure bool) (*Repo, error) {
+	helm, err := helmclassic.NewRaw(u, user, pass, c, insecure)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	return &Repo{url: u, username: user, password: pass, helm: helm, cache: c}, nil
+	return &Repo{url: u, username: user, password: pass, helm: helm, cache: c, insecure: insecure}, nil
 }
 
 // GetUploadURL returns the URL to upload a chart
@@ -110,13 +112,18 @@ func (r *Repo) Upload(file string, _ *chart.Metadata) error {
 
 	reqID := utils.EncodeSha1(u + file)
 	klog.V(4).Infof("[%s] POST %q", reqID, u)
-	client := &http.Client{}
+	client := http.DefaultClient
+	if r.insecure {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}
+		client = &http.Client{Transport: tr}
+	}
 	res, err := client.Do(req)
 	if err != nil {
 		return errors.Annotatef(err, "uploading %q chart", file)
 	}
 	defer res.Body.Close()
-
 	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
 		bodyStr := utils.HTTPResponseBody(res)
 		return errors.Errorf("unable to fetch index.yaml, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)

--- a/pkg/client/harbor/harbor_test.go
+++ b/pkg/client/harbor/harbor_test.go
@@ -71,8 +71,8 @@ func prepareTest(t *testing.T) (*harbor.Repo, error) {
 		t.Fatal(err)
 	}
 
-	// Create chartmuseum client
-	client, err := harbor.New(harborRepo, cache)
+	// Create harbor client
+	client, err := harbor.New(harborRepo, cache, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/helmclassic/helmclassic_test.go
+++ b/pkg/client/helmclassic/helmclassic_test.go
@@ -70,7 +70,7 @@ func prepareTest(t *testing.T, indexFileName string) *helmclassic.Repo {
 	t.Cleanup(func() { os.RemoveAll(cacheDir) })
 
 	// Create chartmuseum client
-	client, err := helmclassic.New(cmRepo, cache)
+	client, err := helmclassic.New(cmRepo, cache, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/oci/oci_test.go
+++ b/pkg/client/oci/oci_test.go
@@ -48,7 +48,7 @@ func prepareTest(t *testing.T) *oci.Repo {
 	t.Cleanup(func() { os.RemoveAll(cacheDir) })
 
 	// Create oci client
-	client, err := oci.New(ociRepo, cache)
+	client, err := oci.New(ociRepo, cache, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/types/types.go
+++ b/pkg/client/types/types.go
@@ -13,6 +13,7 @@ type ChartDetails struct {
 // ClientOpts allows to configure a client
 type ClientOpts struct {
 	cacheDir string
+	insecure bool
 }
 
 // Option is an option value used to create a new syncer instance.
@@ -25,10 +26,25 @@ func WithCache(dir string) Option {
 	}
 }
 
+// WithInsecure enables insecure SSL connections
+func WithInsecure(enable bool) Option {
+	return func(s *ClientOpts) {
+		s.insecure = enable
+	}
+}
+
 // GetCache returns the cache directory
 func (o *ClientOpts) GetCache() string {
 	if o == nil {
 		return ""
 	}
 	return o.cacheDir
+}
+
+// GetInsecure returns if insecure connections are allowed
+func (o *ClientOpts) GetInsecure() bool {
+	if o == nil {
+		return false
+	}
+	return o.insecure
 }

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -27,6 +27,7 @@ type Syncer struct {
 	dryRun        bool
 	autoDiscovery bool
 	fromDate      string
+	insecure      bool
 
 	// TODO(jdrios): Cache index in local filesystem to speed
 	// up re-runs
@@ -69,6 +70,13 @@ func WithWorkdir(dir string) Option {
 	}
 }
 
+// WithInsecure configures the syncer to allow insecure SSL connections
+func WithInsecure(enable bool) Option {
+	return func(s *Syncer) {
+		s.insecure = enable
+	}
+}
+
 // New creates a new syncer using Client
 func New(source *api.SourceRepo, target *api.TargetRepo, opts ...Option) (*Syncer, error) {
 	s := &Syncer{
@@ -91,12 +99,12 @@ func New(source *api.SourceRepo, target *api.TargetRepo, opts ...Option) (*Synce
 		return nil, errors.Trace(err)
 	}
 
-	srcCli, err := core.NewClient(source.GetRepo(), types.WithCache(s.workdir))
+	srcCli, err := core.NewClient(source.GetRepo(), types.WithCache(s.workdir), types.WithInsecure(s.insecure))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
-	dstCli, err := core.NewClient(target.GetRepo(), types.WithCache(s.workdir))
+	dstCli, err := core.NewClient(target.GetRepo(), types.WithCache(s.workdir), types.WithInsecure(s.insecure))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
This PR adds a `--insecure` command-line flag to allow skipping TLS checks for example when using self-signed certificate during development or testing.

Fixes https://github.com/bitnami-labs/charts-syncer/issues/78