### PR TITLE
feat: Update repository URL references in dependencies files

### DIFF
--- a/internal/chart/chart_test.go
+++ b/internal/chart/chart_test.go
@@ -18,7 +18,7 @@ var (
 	}
 	target = &api.TargetRepo{
 		Repo: &api.Repo{
-			Url:  "http://fake.target/com",
+			Url:  "http://fake.target.com",
 			Kind: api.Kind_CHARTMUSEUM,
 			Auth: &api.Auth{
 				Username: "user",

--- a/internal/chart/dependency_test.go
+++ b/internal/chart/dependency_test.go
@@ -102,7 +102,7 @@ func TestUpdateRequirementsFile(t *testing.T) {
 	if got := newDeps.Dependencies[0].Repository; got != want {
 		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
 	}
-	want = "5.5.5"
+	want = "5.x.x"
 	if got := newDeps.Dependencies[0].Version; got != want {
 		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
 	}
@@ -176,7 +176,7 @@ func TestUpdateChartMetadataFile(t *testing.T) {
 	if got := chartMetadata.Dependencies[0].Repository; got != want {
 		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
 	}
-	want = "5.19.1"
+	want = "5.x.x"
 	if got := chartMetadata.Dependencies[0].Version; got != want {
 		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
 	}
@@ -199,22 +199,6 @@ func TestUpdateChartMetadataFile(t *testing.T) {
 	want = "5.19.1"
 	if got := newLock.Dependencies[0].Version; got != want {
 		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
-	}
-}
-
-func TestFindDepByName(t *testing.T) {
-	deps := &dependencies{
-		Dependencies: []*chart.Dependency{
-			{Name: "mariadb", Version: "1.2.3"},
-			{Name: "postgresql", Version: "4.5.6"},
-		},
-	}
-	dep := findDepByName(deps.Dependencies, "postgresql")
-	if dep.Name != "postgresql" {
-		t.Errorf("wrong dependency, got: %s , want: %s", dep.Name, "postgresql")
-	}
-	if dep.Version != "4.5.6" {
-		t.Errorf("wrong dependency, got: %s , want: %s", dep.Version, "4.5.6")
 	}
 }
 

--- a/internal/chart/dependency_test.go
+++ b/internal/chart/dependency_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/bitnami-labs/charts-syncer/api"
 	"github.com/bitnami-labs/charts-syncer/internal/utils"
 	"helm.sh/helm/v3/pkg/chart"
 	"sigs.k8s.io/yaml"
@@ -214,5 +215,39 @@ func TestFindDepByName(t *testing.T) {
 	}
 	if dep.Version != "4.5.6" {
 		t.Errorf("wrong dependency, got: %s , want: %s", dep.Version, "4.5.6")
+	}
+}
+
+func TestGetDependencyRepoURL(t *testing.T) {
+	tests := map[string]struct {
+		targetRepo *api.Repo
+		want       string
+	}{
+		"not oci repo": {
+			&api.Repo{
+				Url:  "https://harbor.endpoint.io/chartrepo/library",
+				Kind: api.Kind_HARBOR,
+			},
+			"https://harbor.endpoint.io/chartrepo/library",
+		},
+		"oci repo": {
+			&api.Repo{
+				Url:  "https://harbor.endpoint.io/my-project/my-charts-library",
+				Kind: api.Kind_OCI,
+			},
+			"oci://harbor.endpoint.io/my-project/my-charts-library",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := getDependencyRepoURL(tc.targetRepo)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tc.want {
+				t.Errorf("got: %q, want %q", got, tc.want)
+			}
+		})
 	}
 }

--- a/internal/chart/dependency_test.go
+++ b/internal/chart/dependency_test.go
@@ -2,7 +2,15 @@ package chart
 
 import (
 	"errors"
+	"io/ioutil"
+	"os"
+	"path"
 	"testing"
+	"time"
+
+	"github.com/bitnami-labs/charts-syncer/internal/utils"
+	"helm.sh/helm/v3/pkg/chart"
+	"sigs.k8s.io/yaml"
 )
 
 func TestLockFilePath(t *testing.T) {
@@ -50,5 +58,161 @@ func TestLockFilePath(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestUpdateRequirementsFile(t *testing.T) {
+	lock := &chart.Lock{
+		Generated: time.Now(),
+		Digest:    "sha256:fe26de7fc873dc8001404168feb920a61ba884a2fe211a7371165ed51bf8cb8b",
+		Dependencies: []*chart.Dependency{
+			{Name: "zookeeper", Version: "5.5.5", Repository: source.GetRepo().GetUrl()},
+		},
+	}
+
+	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
+	if err != nil {
+		t.Fatalf("error creating temporary: %s", testTmpDir)
+	}
+	defer os.RemoveAll(testTmpDir)
+
+	sourceChart := "../../testdata/kafka-10.3.3.tgz"
+	if err := utils.Untar(sourceChart, testTmpDir); err != nil {
+		t.Fatal(err)
+	}
+
+	chartPath := path.Join(testTmpDir, "kafka")
+	requirementsFile := path.Join(chartPath, RequirementsFilename)
+	if err := updateRequirementsFile(chartPath, lock, source.GetRepo(), target.GetRepo()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test requirements file
+	requirements, err := ioutil.ReadFile(requirementsFile)
+	if err != nil {
+		t.Fatalf("error reading updated %s file", requirementsFile)
+	}
+	newDeps := &dependencies{}
+	err = yaml.Unmarshal(requirements, newDeps)
+	if err != nil {
+		t.Fatalf("error unmarshaling %s file", requirementsFile)
+	}
+	want := target.GetRepo().GetUrl()
+	if got := newDeps.Dependencies[0].Repository; got != want {
+		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
+	}
+	want = "5.5.5"
+	if got := newDeps.Dependencies[0].Version; got != want {
+		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
+	}
+
+	// Test requirements lock file
+	requirementsFileLock := path.Join(chartPath, RequirementsLockFilename)
+	requirementsLock, err := ioutil.ReadFile(requirementsFileLock)
+	if err != nil {
+		t.Fatalf("error reading updated %s file", requirementsFileLock)
+	}
+	newLock := &chart.Lock{}
+	err = yaml.Unmarshal(requirementsLock, newLock)
+	if err != nil {
+		t.Fatalf("error unmarshaling %s file", requirementsFileLock)
+	}
+	want = target.GetRepo().GetUrl()
+	if got := newLock.Dependencies[0].Repository; got != want {
+		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
+	}
+	want = "5.5.5"
+	if got := newLock.Dependencies[0].Version; got != want {
+		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
+	}
+}
+
+func TestUpdateChartMetadataFile(t *testing.T) {
+	lock := &chart.Lock{
+		Generated: time.Now(),
+		Digest:    "sha256:fe26de7fc873dc8001404168feb920a61ba884a2fe211a7371165ed51bf8cb8b",
+		Dependencies: []*chart.Dependency{
+			{Name: "zookeeper", Version: "5.19.1", Repository: source.GetRepo().GetUrl()},
+		},
+	}
+
+	testTmpDir, err := ioutil.TempDir("", "charts-syncer-tests")
+	if err != nil {
+		t.Fatalf("error creating temporary: %s", testTmpDir)
+	}
+	defer os.RemoveAll(testTmpDir)
+
+	sourceFile, err := ioutil.ReadFile("../../testdata/kafka-chart.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	chartPath := path.Join(testTmpDir, "kafka")
+	chartFile := path.Join(chartPath, ChartFilename)
+	err = os.MkdirAll(chartPath, 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = ioutil.WriteFile(chartFile, sourceFile, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateChartMetadataFile(chartPath, lock, source.GetRepo(), target.GetRepo()); err != nil {
+		t.Fatal(err)
+	}
+
+	// Test Chart.yaml file
+	chartFileContent, err := ioutil.ReadFile(chartFile)
+	if err != nil {
+		t.Fatalf("error reading updated %s file", chartFile)
+	}
+	chartMetadata := &chart.Metadata{}
+	err = yaml.Unmarshal(chartFileContent, chartMetadata)
+	if err != nil {
+		t.Fatalf("error unmarshaling %s file", chartFile)
+	}
+	want := target.Repo.Url
+	if got := chartMetadata.Dependencies[0].Repository; got != want {
+		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
+	}
+	want = "5.19.1"
+	if got := chartMetadata.Dependencies[0].Version; got != want {
+		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
+	}
+
+	// Test Chart.lock file
+	chartFileLock := path.Join(chartPath, ChartLockFilename)
+	chartLock, err := ioutil.ReadFile(chartFileLock)
+	if err != nil {
+		t.Fatalf("error reading updated %s file", chartFileLock)
+	}
+	newLock := &chart.Lock{}
+	err = yaml.Unmarshal(chartLock, newLock)
+	if err != nil {
+		t.Fatalf("error unmarshaling %s file", chartFileLock)
+	}
+	want = target.GetRepo().GetUrl()
+	if got := newLock.Dependencies[0].Repository; got != want {
+		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
+	}
+	want = "5.19.1"
+	if got := newLock.Dependencies[0].Version; got != want {
+		t.Errorf("incorrect modification, got: %s, want: %s", got, want)
+	}
+}
+
+func TestFindDepByName(t *testing.T) {
+	deps := &dependencies{
+		Dependencies: []*chart.Dependency{
+			{Name: "mariadb", Version: "1.2.3"},
+			{Name: "postgresql", Version: "4.5.6"},
+		},
+	}
+	dep := findDepByName(deps.Dependencies, "postgresql")
+	if dep.Name != "postgresql" {
+		t.Errorf("wrong dependency, got: %s , want: %s", dep.Name, "postgresql")
+	}
+	if dep.Version != "4.5.6" {
+		t.Errorf("wrong dependency, got: %s , want: %s", dep.Version, "4.5.6")
 	}
 }

--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -85,7 +85,7 @@ func (s *Syncer) SyncPendingCharts(names ...string) error {
 		// Update deps
 		if hasDeps {
 			klog.V(3).Infof("Building %q dependencies", id)
-			if err := chart.BuildDependencies(chartPath, s.cli.dst); err != nil {
+			if err := chart.BuildDependencies(chartPath, s.cli.dst, s.source.GetRepo(), s.target.GetRepo()); err != nil {
 				klog.Errorf("unable to build %q chart dependencies: %+v", id, err)
 				errs = multierror.Append(errs, errors.Trace(err))
 				continue


### PR DESCRIPTION
Fixes #81
Fixes #100

I have recovered (and adapted a bit) several functions deleted at https://github.com/bitnami-labs/charts-syncer/pull/76/. In that PR, we removed `helm` dependency, so we stopped using helm cli to build the dependencies and started to do it on our own. Due to that, we stopped modifying dependencies files to point to the new repository url.