### PR TITLE
Add the ability to use with github.io and github.com charts

### DIFF
--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -286,12 +286,14 @@ func NormalizeChartURL(repoURL, indexURL string) (string, error) {
 	}
 	chartURL := iu.String()
 
-	if iu.Host != "github.com" {
-		if iu.Host == "" {
-			chartURL = fmt.Sprintf("%s/%s", repoURL, iu.String())
-		} else if iu.Host != ru.Host {
-			return "", errors.Errorf("index host (%s) and repo host (%s) are different", iu.Host, ru.Host)
-		}
+	if iu.Host != "" {
+		return indexURL, nil
+	}
+
+	if iu.Host == "" {
+		chartURL = fmt.Sprintf("%s/%s", repoURL, iu.String())
+	} else if iu.Host != ru.Host {
+		return "", errors.Errorf("index host (%s) and repo host (%s) are different", iu.Host, ru.Host)
 	}
 	return chartURL, nil
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -285,10 +285,13 @@ func NormalizeChartURL(repoURL, indexURL string) (string, error) {
 		return "", errors.Trace(err)
 	}
 	chartURL := iu.String()
-	if iu.Host == "" {
-		chartURL = fmt.Sprintf("%s/%s", repoURL, iu.String())
-	} else if iu.Host != ru.Host {
-		return "", errors.Errorf("index host (%s) and repo host (%s) are different", iu.Host, ru.Host)
+
+	if iu.Host != "github.com" {
+		if iu.Host == "" {
+			chartURL = fmt.Sprintf("%s/%s", repoURL, iu.String())
+		} else if iu.Host != ru.Host {
+			return "", errors.Errorf("index host (%s) and repo host (%s) are different", iu.Host, ru.Host)
+		}
 	}
 	return chartURL, nil
 }

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -201,3 +201,34 @@ func TestNormalizeChartURL(t *testing.T) {
 		})
 	}
 }
+
+func TestGithubChartURL(t *testing.T) {
+	want := "https://github.com/nats/releases/v1.2.3/nats-1.2.3.tgz"
+	tests := []struct {
+		desc          string
+		repoURL       string
+		chartURL      string
+		shouldFail    bool
+		expectedError error
+	}{
+		{
+			desc:     "github.io repo and github.com chart",
+			repoURL:  "https://chart.github.io/helm-charts",
+			chartURL: "https://github.com/nats/releases/v1.2.3/nats-1.2.3.tgz",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := NormalizeChartURL(tc.repoURL, tc.chartURL)
+			if tc.shouldFail {
+				if err.Error() != tc.expectedError.Error() {
+					t.Errorf("error does not match: [%v:%v]", tc.expectedError, err)
+				}
+			} else {
+				if got != want {
+					t.Errorf("wrong download URL. got: %v, want: %v", got, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Today i've started to use this solution and I have encountered a problem with it.

I've tried to sync ingress-nginx helm charts but the following showed up.

```bash
kubectl logs -f charts-syncer-test-ltstj
I0817 11:05:34.533952       1 sync.go:33] Using config file: "/charts-syncer.yaml"
I0817 11:05:34.534501       1 syncer.go:96] Using workdir: "/.charts-syncer"
I0817 11:05:34.534744       1 cache.go:38] Allocating cache dir: "/.charts-syncer/077ebcf1faa6f9081bce292dd5a7de089a21971d"
I0817 11:05:34.534877       1 helmclassic.go:48] [0de643e32b4220f64888abca0464621f42fe743e] GET "https://kubernetes.github.io/ingress-nginx/index.yaml"
I0817 11:05:39.651954       1 helmclassic.go:66] [0de643e32b4220f64888abca0464621f42fe743e] HTTP Status: 200 OK
I0817 11:05:39.685720       1 cache.go:38] Allocating cache dir: "/.charts-syncer/5b6fde763f9acb2fe436de40e9ffbc348b2e7e0c"
I0817 11:05:39.685913       1 helmclassic.go:48] [c307586fa56b69b76502f3812cb493a79f952011] GET "https://harbor.my.tld/chartrepo/internal-repo/index.yaml"
I0817 11:05:40.046051       1 helmclassic.go:66] [c307586fa56b69b76502f3812cb493a79f952011] HTTP Status: 200 OK
I0817 11:05:40.280086       1 index.go:85] Publishing threshold set to "1970-01-01 00:00:00 +0000 UTC"
I0817 11:05:40.280128       1 index.go:97] Indexing "ingress-nginx" charts...
I0817 11:05:40.280203       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-4.0.0-beta.3.tgz }
E0817 11:05:40.280274       1 index.go:127] unable to load "ingress-nginx-4.0.0-beta.3" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.280352       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-4.0.0-beta.2.tgz }
E0817 11:05:40.280987       1 index.go:127] unable to load "ingress-nginx-4.0.0-beta.2" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281024       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-4.0.0-beta.1.tgz }
E0817 11:05:40.281057       1 index.go:127] unable to load "ingress-nginx-4.0.0-beta.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281091       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.35.0.tgz }
E0817 11:05:40.281123       1 index.go:127] unable to load "ingress-nginx-3.35.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281152       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.34.0.tgz }
E0817 11:05:40.281181       1 index.go:127] unable to load "ingress-nginx-3.34.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281209       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.33.0.tgz }
E0817 11:05:40.281240       1 index.go:127] unable to load "ingress-nginx-3.33.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281270       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.32.0.tgz }
E0817 11:05:40.281305       1 index.go:127] unable to load "ingress-nginx-3.32.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281341       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.31.0.tgz }
E0817 11:05:40.281380       1 index.go:127] unable to load "ingress-nginx-3.31.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281410       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.30.0.tgz }
E0817 11:05:40.281440       1 index.go:127] unable to load "ingress-nginx-3.30.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281469       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.29.0.tgz }
E0817 11:05:40.281497       1 index.go:127] unable to load "ingress-nginx-3.29.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281524       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.28.0.tgz }
E0817 11:05:40.281552       1 index.go:127] unable to load "ingress-nginx-3.28.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281580       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.27.0.tgz }
E0817 11:05:40.281606       1 index.go:127] unable to load "ingress-nginx-3.27.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281633       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.26.0.tgz }
E0817 11:05:40.281661       1 index.go:127] unable to load "ingress-nginx-3.26.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281688       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.25.0.tgz }
E0817 11:05:40.281714       1 index.go:127] unable to load "ingress-nginx-3.25.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281742       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.24.0.tgz }
E0817 11:05:40.281770       1 index.go:127] unable to load "ingress-nginx-3.24.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281799       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.23.0.tgz }
E0817 11:05:40.281830       1 index.go:127] unable to load "ingress-nginx-3.23.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281861       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.22.0.tgz }
E0817 11:05:40.281891       1 index.go:127] unable to load "ingress-nginx-3.22.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281927       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.21.0.tgz }
E0817 11:05:40.281956       1 index.go:127] unable to load "ingress-nginx-3.21.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.281988       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.20.1.tgz }
E0817 11:05:40.282015       1 index.go:127] unable to load "ingress-nginx-3.20.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282047       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.20.0.tgz }
E0817 11:05:40.282073       1 index.go:127] unable to load "ingress-nginx-3.20.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282102       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.19.0.tgz }
E0817 11:05:40.282134       1 index.go:127] unable to load "ingress-nginx-3.19.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282162       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.18.0.tgz }
E0817 11:05:40.282189       1 index.go:127] unable to load "ingress-nginx-3.18.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282216       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.17.0.tgz }
E0817 11:05:40.282242       1 index.go:127] unable to load "ingress-nginx-3.17.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282272       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.16.1.tgz }
E0817 11:05:40.282305       1 index.go:127] unable to load "ingress-nginx-3.16.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282333       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.15.2.tgz }
E0817 11:05:40.282362       1 index.go:127] unable to load "ingress-nginx-3.15.2" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282393       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.13.0.tgz }
E0817 11:05:40.282423       1 index.go:127] unable to load "ingress-nginx-3.13.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282451       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.12.0.tgz }
E0817 11:05:40.282480       1 index.go:127] unable to load "ingress-nginx-3.12.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282508       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.11.1.tgz }
E0817 11:05:40.282534       1 index.go:127] unable to load "ingress-nginx-3.11.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282562       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.11.0.tgz }
E0817 11:05:40.282588       1 index.go:127] unable to load "ingress-nginx-3.11.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282616       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.10.1.tgz }
E0817 11:05:40.282644       1 index.go:127] unable to load "ingress-nginx-3.10.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282675       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.10.0.tgz }
E0817 11:05:40.282702       1 index.go:127] unable to load "ingress-nginx-3.10.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282732       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.9.0.tgz }
E0817 11:05:40.282758       1 index.go:127] unable to load "ingress-nginx-3.9.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282784       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.8.0.tgz }
E0817 11:05:40.282809       1 index.go:127] unable to load "ingress-nginx-3.8.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282838       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.7.1.tgz }
E0817 11:05:40.282865       1 index.go:127] unable to load "ingress-nginx-3.7.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282892       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.7.0.tgz }
E0817 11:05:40.282921       1 index.go:127] unable to load "ingress-nginx-3.7.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.282953       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.6.0.tgz }
E0817 11:05:40.282982       1 index.go:127] unable to load "ingress-nginx-3.6.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283007       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.5.1.tgz }
E0817 11:05:40.283032       1 index.go:127] unable to load "ingress-nginx-3.5.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283059       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.4.1.tgz }
E0817 11:05:40.283085       1 index.go:127] unable to load "ingress-nginx-3.4.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283110       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.4.0.tgz }
E0817 11:05:40.283138       1 index.go:127] unable to load "ingress-nginx-3.4.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283166       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.3.1.tgz }
E0817 11:05:40.283195       1 index.go:127] unable to load "ingress-nginx-3.3.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283226       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.3.0.tgz }
E0817 11:05:40.283256       1 index.go:127] unable to load "ingress-nginx-3.3.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283288       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.2.0.tgz }
E0817 11:05:40.283317       1 index.go:127] unable to load "ingress-nginx-3.2.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283345       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.1.0.tgz }
E0817 11:05:40.283371       1 index.go:127] unable to load "ingress-nginx-3.1.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283395       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-3.0.0.tgz }
E0817 11:05:40.283421       1 index.go:127] unable to load "ingress-nginx-3.0.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283447       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.16.0.tgz }
E0817 11:05:40.283475       1 index.go:127] unable to load "ingress-nginx-2.16.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283502       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.15.0.tgz }
E0817 11:05:40.283528       1 index.go:127] unable to load "ingress-nginx-2.15.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283582       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.14.0.tgz }
E0817 11:05:40.283613       1 index.go:127] unable to load "ingress-nginx-2.14.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283643       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.13.0.tgz }
E0817 11:05:40.283671       1 index.go:127] unable to load "ingress-nginx-2.13.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283698       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.12.1.tgz }
E0817 11:05:40.283725       1 index.go:127] unable to load "ingress-nginx-2.12.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283751       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.12.0.tgz }
E0817 11:05:40.283781       1 index.go:127] unable to load "ingress-nginx-2.12.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283809       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.11.3.tgz }
E0817 11:05:40.283838       1 index.go:127] unable to load "ingress-nginx-2.11.3" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283866       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.11.2.tgz }
E0817 11:05:40.283892       1 index.go:127] unable to load "ingress-nginx-2.11.2" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283921       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.11.1.tgz }
E0817 11:05:40.283948       1 index.go:127] unable to load "ingress-nginx-2.11.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.283973       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.11.0.tgz }
E0817 11:05:40.283999       1 index.go:127] unable to load "ingress-nginx-2.11.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284025       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.10.0.tgz }
E0817 11:05:40.284053       1 index.go:127] unable to load "ingress-nginx-2.10.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284079       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.9.1.tgz }
E0817 11:05:40.284105       1 index.go:127] unable to load "ingress-nginx-2.9.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284133       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.9.0.tgz }
E0817 11:05:40.284158       1 index.go:127] unable to load "ingress-nginx-2.9.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284183       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.8.0.tgz }
E0817 11:05:40.284209       1 index.go:127] unable to load "ingress-nginx-2.8.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284235       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.7.1.tgz }
E0817 11:05:40.284263       1 index.go:127] unable to load "ingress-nginx-2.7.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284298       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.7.0.tgz }
E0817 11:05:40.284329       1 index.go:127] unable to load "ingress-nginx-2.7.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284359       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.6.0.tgz }
E0817 11:05:40.284390       1 index.go:127] unable to load "ingress-nginx-2.6.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284420       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.5.0.tgz }
E0817 11:05:40.284449       1 index.go:127] unable to load "ingress-nginx-2.5.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284478       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.4.0.tgz }
E0817 11:05:40.284506       1 index.go:127] unable to load "ingress-nginx-2.4.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284534       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.3.0.tgz }
E0817 11:05:40.284563       1 index.go:127] unable to load "ingress-nginx-2.3.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284593       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.2.0.tgz }
E0817 11:05:40.284622       1 index.go:127] unable to load "ingress-nginx-2.2.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284651       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.1.0.tgz }
E0817 11:05:40.284679       1 index.go:127] unable to load "ingress-nginx-2.1.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284715       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.0.3.tgz }
E0817 11:05:40.284748       1 index.go:127] unable to load "ingress-nginx-2.0.3" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284776       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.0.2.tgz }
E0817 11:05:40.284804       1 index.go:127] unable to load "ingress-nginx-2.0.2" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284832       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.0.1.tgz }
E0817 11:05:40.284860       1 index.go:127] unable to load "ingress-nginx-2.0.1" chart: index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.284891       1 cache.go:54] cache hit { op:has, id:077ebcf1faa6f9081bce292dd5a7de089a21971d, filename:ingress-nginx-2.0.0.tgz }
E0817 11:05:40.284918       1 index.go:127] unable to load "ingress-nginx-2.0.0" chart: index host (github.com) and repo host (kubernetes.github.io) are different
W0817 11:05:40.284933       1 sync.go:30] There were some problems loading the information of the requested charts: 70 errors occurred:
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
index host (github.com) and repo host (kubernetes.github.io) are different
I0817 11:05:40.285074       1 sync.go:45] There are no charts out of sync!
```

Here is my configmap:
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: charts-syncer-config
data:
  charts-syncer.yaml: |-
    #
    # Example config file
    #
    source:
      repo:
        kind: "HELM"
        url: "https://kubernetes.github.io/ingress-nginx" # local test source repo
        # auth:
        #   username: "USERNAME"
        #   password: "PASSWORD"
    target:
      repoName: ingress-nginx
      containerRegistry: "harbor.my.tld"
      containerRepository: "sync"
      repo:
        kind: "HARBOR"
        url: "https://harbor.my.tld/chartrepo/internal-repo" # local test target repo
        auth:
          username: "user"
          password: "ABCD"
```

This PR will fix this issue.