### PR TITLE
feature: add version command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.15
+      - image: circleci/golang:1.16
     steps:
       - checkout
       - run: make build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
       - name: Release
         uses: goreleaser/goreleaser-action@v2
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist
 
 ### Editors/IDEs ###
 .vscode
+.idea

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,6 +8,8 @@ builds:
       - GO111MODULE=on
     main: ./main.go
     binary: charts-syncer
+    ldflags:
+      - -X github.com/bitnami-labs/charts-syncer/cmd.Version={{.Version}}
 dockers:
   -
     ids:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,7 +9,7 @@ builds:
     main: ./main.go
     binary: charts-syncer
     ldflags:
-      - -X github.com/bitnami-labs/charts-syncer/cmd.Version={{.Version}}
+      - -X github.com/bitnami-labs/charts-syncer/cmd.version={{.Version}}
 dockers:
   -
     ids:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 OUTPUT = ./dist/charts-syncer
 GO_SOURCES = $(shell find . -type f -name '*.go')
+VERSION := $(or $(VERSION), dev)
+LDFLAGS="-X github.com/bitnami-labs/charts-syncer/cmd.Version=$(VERSION)"
 
 test:
 	GO111MODULE=on go test ./...
@@ -15,4 +17,4 @@ gen:
 	go generate github.com/bitnami-labs/charts-syncer/...
 
 build: $(GO_SOURCES)
-	GO111MODULE=on CGO_ENABLED=0 go build -o $(OUTPUT) ./
+	GO111MODULE=on CGO_ENABLED=0 go build -o $(OUTPUT) -ldflags ${LDFLAGS} ./

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 OUTPUT = ./dist/charts-syncer
 GO_SOURCES = $(shell find . -type f -name '*.go')
 VERSION := $(or $(VERSION), dev)
-LDFLAGS="-X github.com/bitnami-labs/charts-syncer/cmd.Version=$(VERSION)"
+LDFLAGS="-X github.com/bitnami-labs/charts-syncer/cmd.version=$(VERSION)"
 
 test:
 	GO111MODULE=on go test ./...

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,6 +36,7 @@ func newRootCmd() *cobra.Command {
 	// Add subcommands
 	cmd.AddCommand(
 		newSyncCmd(),
+		newVersionCmd(),
 	)
 
 	// Workaround to disable help subcommand

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var Version = "dev"
+
+func versionHelp() string {
+	return fmt.Sprint("Print the version number of charts-syncer")
+}
+
+func newVersionCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "version",
+		Short:  versionHelp(),
+		Long: versionHelp(),
+		Example: versionHelp(),
+		Run: func(cmd *cobra.Command, args []string) {
+			cmd.Printf("charts-syncer version: %s\n", Version)
+		},
+	}
+
+	return cmd
+}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,24 +1,21 @@
 package cmd
 
 import (
-	"fmt"
 	"github.com/spf13/cobra"
 )
 
-var Version = "dev"
+var version = "dev"
 
 func versionHelp() string {
-	return fmt.Sprint("Print the version number of charts-syncer")
+	return "Print the version number of charts-syncer"
 }
 
 func newVersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "version",
-		Short:  versionHelp(),
-		Long: versionHelp(),
-		Example: versionHelp(),
+		Use:   "version",
+		Short: versionHelp(),
 		Run: func(cmd *cobra.Command, args []string) {
-			cmd.Printf("charts-syncer version: %s\n", Version)
+			cmd.Printf("%s\n", version)
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/bitnami-labs/charts-syncer
 
-go 1.15
+go 1.16
 
 // Pin to specific version to not hit the next issue:
 // Error:    vendor/github.com/docker/distribution/registry/registry.go:157:10: undefined: letsencrypt.Manager

--- a/go.sum
+++ b/go.sum
@@ -103,7 +103,6 @@ github.com/bitnami-labs/pbjson v1.1.0 h1:ru8Zx5gB1PY+M4Q171XI3Gw99pWvOnrdOC4PlPG
 github.com/bitnami-labs/pbjson v1.1.0/go.mod h1:EjoYVFm8XCve6TVhBmjm/7O54q5GnAr+9rHXy5wTQ2A=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
-github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1 h1:pgAtgj+A31JBVtEHu2uHuEx0n+2ukqUJnS2vVe5pQNA=
 github.com/bshuster-repo/logrus-logstash-hook v0.4.1/go.mod h1:zsTqEiSzDgAa/8GZR7E1qaXrhYNDKBYy5/dWPTIflbk=
@@ -316,7 +315,6 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang-sql/civil v0.0.0-20190719163853-cb61b32ac6fe/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
-github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -486,7 +484,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxv
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.5/go.mod h1:9r2w37qlBe7rQ6e1fg1S/9xpWHSnaqNdHD3WcMdbPDA=


### PR DESCRIPTION
This PR adds a new `version` command to output the version of the tool.

Additionally it updates the required go version to 1.16