### PR TITLE
refactor: rename reader and writer interfaces

### DIFF
--- a/internal/chart/dependency.go
+++ b/internal/chart/dependency.go
@@ -114,7 +114,7 @@ func GetLockAPIVersion(chartPath string) (string, error) {
 //
 // It reads the lock file to download the versions from the target
 // chart repository (it assumes all charts are stored in a single repo).
-func BuildDependencies(chartPath string, r client.Reader, sourceRepo, targetRepo *api.Repo) error {
+func BuildDependencies(chartPath string, r client.ChartsReader, sourceRepo, targetRepo *api.Repo) error {
 	// Build deps manually for OCI as helm does not support it yet
 	if err := os.RemoveAll(path.Join(chartPath, "charts")); err != nil {
 		return errors.Trace(err)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -8,8 +8,8 @@ import (
 // This package defines the interfaces that clients needs to satisfy in order to work with chart repositories or
 // intermediate bundles directories.
 
-// Reader defines the methods that a ReadOnly chart or bundle client should implement.
-type Reader interface {
+// ChartsReader defines the methods that a ReadOnly chart or bundle client should implement.
+type ChartsReader interface {
 	Fetch(name string, version string) (string, error)
 	List() ([]string, error)
 	ListChartVersions(name string) ([]string, error)
@@ -20,13 +20,13 @@ type Reader interface {
 	Reload() error
 }
 
-// Writer defines the methods that a WriteOnly chart or bundle client should implement.
-type Writer interface {
+// ChartsWriter defines the methods that a WriteOnly chart or bundle client should implement.
+type ChartsWriter interface {
 	Upload(filepath string, metadata *chart.Metadata) error
 }
 
-// ReaderWriter defines the methods that a chart or bundle client should implement
-type ReaderWriter interface {
-	Reader
-	Writer
+// ChartsReaderWriter defines the methods that a chart or bundle client should implement
+type ChartsReaderWriter interface {
+	ChartsReader
+	ChartsWriter
 }

--- a/pkg/client/intermediate/intermediate.go
+++ b/pkg/client/intermediate/intermediate.go
@@ -23,14 +23,14 @@ var (
 type chartVersions []string
 
 // BundlesDir allows to operate a chart bundles directory
-// It should implement pkg/client ReaderWriter interface
+// It should implement pkg/client ChartsReaderWriter interface
 type BundlesDir struct {
 	dir     string
 	entries map[string]chartVersions
 }
 
-// NewIntermediateClient returns a ReaderWriter object
-func NewIntermediateClient(intermediateBundlesPath string) (client.ReaderWriter, error) {
+// NewIntermediateClient returns a ChartsReaderWriter object
+func NewIntermediateClient(intermediateBundlesPath string) (client.ChartsReaderWriter, error) {
 	return New(intermediateBundlesPath)
 }
 

--- a/pkg/client/repo/core.go
+++ b/pkg/client/repo/core.go
@@ -18,7 +18,7 @@ import (
 )
 
 // NewClient returns a Client object
-func NewClient(repo *api.Repo, opts ...types.Option) (client.ReaderWriter, error) {
+func NewClient(repo *api.Repo, opts ...types.Option) (client.ChartsReaderWriter, error) {
 	copts := &types.ClientOpts{}
 	for _, o := range opts {
 		o(copts)

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -14,8 +14,8 @@ import (
 
 // Clients holds the source and target chart repo clients
 type Clients struct {
-	src client.ReaderWriter
-	dst client.ReaderWriter
+	src client.ChartsReaderWriter
+	dst client.ChartsReaderWriter
 }
 
 // A Syncer can be used to sync a source and target chart repos.


### PR DESCRIPTION
Follow up from #120. We can use a more meaningful name for these interfaces