### PR TITLE
fix: Update relok8s library to support multi-level dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.58
+	github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.59
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.7.0

--- a/go.sum
+++ b/go.sum
@@ -1179,6 +1179,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.58 h1:ngS0+OoyBZXfOFgMqizcmiiLj0s/vBvK4rTNJyijXWk=
 github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.58/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
+github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.59 h1:mU1YO5fCl1DnYgkHJ8GX1DtyNBdVUooZzz04P9i17l0=
+github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.59/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=


### PR DESCRIPTION
Update the relok8s dependency to leverage the new multi-leveled, recursive dependency update approach https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/113

This will allow us to sync Helm Charts like `wavefront-adapter-for-istio` which has 3 levels of dependencies 

Tested with the patch and it worked
```
go run main.go sync -c ~/work/bitnami/playground/demo-charts-syncer/config.yaml -v3 --from-date 2021-11-29                        
I1220 13:34:49.011173 3837906 sync.go:33] Using config file: "/home/migmartri/work/bitnami/playground/demo-charts-syncer/config.yaml"                                                                                                                                               
I1220 13:34:49.011573 3837906 syncer.go:114] Using workdir: "/home/migmartri/.charts-syncer"                                              
W1220 13:34:53.778011 3837906 syncer.go:168] Ignoring skipDependencies option as dependency sync is not supported if container image relocation is true or syncing from/to intermediate directory 
I1220 13:34:53.778028 3837906 index.go:98] Indexing "wavefront-adapter-for-istio" charts...                                                                                                                                                                                         
I1220 13:34:55.182950 3837906 sync.go:47] There is 1 chart out of sync!                                                                   
I1220 13:34:55.182987 3837906 sync.go:55] Syncing "wavefront-adapter-for-istio-1.0.10" chart...                                                                                                                                                                                     
I1220 13:34:55.183002 3837906 sync.go:57] Processing "wavefront-adapter-for-istio-1.0.10" chart...                                        
.relok8s-images.yaml hints file found                                                                                                     
Computing relocation...                                                                                                                                                                                                                                                             
                                                                                                                                          
Relocating wavefront-adapter-for-istio@1.0.10...                                                                                          
Pushing us-west1-docker.pkg.dev/bitnamigcetest2/relok8s-test/containers/wavefront-adapter-for-istio:0.1.5-centos-7-r233...                                                                                                                                                          
Done                                                                                                                                      
Pushing us-west1-docker.pkg.dev/bitnamigcetest2/relok8s-test/containers/wavefront-kubernetes-collector:1.7.4-scratch-r0...                                                                                                                                                          
Done                                                                                                                                                                                                                                                                                
Pushing us-west1-docker.pkg.dev/bitnamigcetest2/relok8s-test/containers/wavefront-proxy:10.9.0-centos-7-r37...                                                                                                                                                                      
Done                                                                                                                                                                                                                                                                                
Pushing us-west1-docker.pkg.dev/bitnamigcetest2/relok8s-test/containers/kube-state-metrics:2.2.4-centos-7-r0...                                                                                                                                                                     
Done                                                                                                                                      
Done moving /tmp/charts-syncer120152087/wavefront-adapter-for-istio-1.0.10.relocated.tgz

```