### PR TITLE
fix: remove .relocated suffix when relok8s is the backend used

### DIFF
--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -196,8 +196,8 @@ func getRelok8sMoveRequest(source *api.Source, target *api.Target, chart *Chart,
 		// Direct syncing
 		// Once https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/94 is solved, we could
 		// specify the name we want for the output file. Until then, we should keep using this template thing
-		outputChartPath := filepath.Join(outdir, "%s-%s.relocated.tgz")
-		packagedChartPath := filepath.Join(outdir, fmt.Sprintf("%s-%s.relocated.tgz", chart.Name, chart.Version))
+		outputChartPath := filepath.Join(outdir, "%s-%s.tgz")
+		packagedChartPath := filepath.Join(outdir, fmt.Sprintf("%s-%s.tgz", chart.Name, chart.Version))
 		return relok8sMoveReq(chart.TgzPath, outputChartPath, target.GetContainerRegistry(), target.GetContainerRepository()), packagedChartPath
 	}
 }

--- a/pkg/syncer/sync_internal_test.go
+++ b/pkg/syncer/sync_internal_test.go
@@ -59,12 +59,12 @@ func TestGetRelok8sMoveRequest(t *testing.T) {
 					},
 					Chart: mover.ChartSpec{
 						Local: &mover.LocalChart{
-							Path: "/tmp/output-dir/%s-%s.relocated.tgz",
+							Path: "/tmp/output-dir/%s-%s.tgz",
 						},
 					},
 				},
 			},
-			wantChartPath: "/tmp/output-dir/chart-A-1.2.3.relocated.tgz",
+			wantChartPath: "/tmp/output-dir/chart-A-1.2.3.tgz",
 		}, {
 			desc: "save bundles with relok8s",
 			source: &api.Source{


### PR DESCRIPTION
Delete the .relocated suffix from chart name so in the target repository is stored as NAME-VERSION.tgz

Fix #125