### PR TITLE
feature: add CLI flag to only sync latest version of charts

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -72,7 +72,7 @@ func newSyncCmd() *cobra.Command {
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			s, err := syncer.New(c.GetSource(), c.GetTarget(),
+			syncerOptions := []syncer.Option{
 				// TODO(jdrios): Some backends may not support discovery
 				syncer.WithAutoDiscovery(true),
 				syncer.WithDryRun(rootDryRun),
@@ -82,7 +82,8 @@ func newSyncCmd() *cobra.Command {
 				syncer.WithContainerImageRelocation(c.RelocateContainerImages),
 				syncer.WithSkipDependencies(syncSkipDependencies),
 				syncer.WithLatestVersionOnly(syncLatestVersionOnly),
-			)
+			}
+			s, err := syncer.New(c.GetSource(), c.GetTarget(), syncerOptions...)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -12,9 +12,10 @@ import (
 )
 
 var (
-	syncFromDate         string
-	syncWorkdir          string
-	syncSkipDependencies bool
+	syncFromDate          string
+	syncWorkdir           string
+	syncSkipDependencies  bool
+	syncLatestVersionOnly bool
 )
 
 var (
@@ -80,6 +81,7 @@ func newSyncCmd() *cobra.Command {
 				syncer.WithInsecure(rootInsecure),
 				syncer.WithContainerImageRelocation(c.RelocateContainerImages),
 				syncer.WithSkipDependencies(syncSkipDependencies),
+				syncer.WithLatestVersionOnly(syncLatestVersionOnly),
 			)
 			if err != nil {
 				return errors.Trace(err)
@@ -92,6 +94,7 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().StringVar(&syncFromDate, "from-date", "", "Date you want to synchronize charts from. Format: YYYY-MM-DD")
 	cmd.Flags().StringVar(&syncWorkdir, "workdir", syncer.DefaultWorkdir(), "Working directory")
 	cmd.Flags().BoolVar(&syncSkipDependencies, "skip-dependencies", false, "Skip syncing chart dependencies")
+	cmd.Flags().BoolVar(&syncLatestVersionOnly, "latest-version-only", false, "Sync only latest version of each chart")
 
 	return cmd
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ go 1.16
 replace gopkg.in/yaml.v3 => github.com/atomatt/yaml v0.0.0-20200403124456-7b932d16ab90
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/bitnami-labs/pbjson v1.1.0
 	github.com/containerd/containerd v1.5.8
 	github.com/distribution/distribution/v3 v3.0.0-20210804104954-38ab4c606ee3

--- a/pkg/syncer/sync_test.go
+++ b/pkg/syncer/sync_test.go
@@ -336,7 +336,11 @@ func TestSyncPendingChartsChartMuseum(t *testing.T) {
 			tc.targetRepo.GetRepo().Url = tTester.GetURL()
 
 			// Create new syncer
-			s, err := syncer.New(tc.sourceRepo, tc.targetRepo, syncer.WithSkipDependencies(tc.skipDependencies), syncer.WithLatestVersionOnly(tc.latestVersionOnly))
+			syncerOptions := []syncer.Option{
+				syncer.WithSkipDependencies(tc.skipDependencies),
+				syncer.WithLatestVersionOnly(tc.latestVersionOnly),
+			}
+			s, err := syncer.New(tc.sourceRepo, tc.targetRepo, syncerOptions...)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/syncer/sync_test.go
+++ b/pkg/syncer/sync_test.go
@@ -91,13 +91,14 @@ func TestFakeSyncPendingCharts(t *testing.T) {
 
 func TestSyncPendingChartsChartMuseum(t *testing.T) {
 	testCases := []struct {
-		desc             string
-		sourceRepo       *api.Source
-		targetRepo       *api.Target
-		skipDependencies bool
-		entries          []string
-		requiredCharts   []string
-		want             []*helmclassic.ChartVersion
+		desc              string
+		sourceRepo        *api.Source
+		targetRepo        *api.Target
+		skipDependencies  bool
+		latestVersionOnly bool
+		entries           []string
+		requiredCharts    []string
+		want              []*helmclassic.ChartVersion
 	}{
 		{
 			desc: "sync etcd and common",
@@ -227,6 +228,78 @@ func TestSyncPendingChartsChartMuseum(t *testing.T) {
 					URLs:    []string{"charts/kafka-14.7.0.tgz"},
 				},
 			},
+		}, {
+			desc: "sync common (all versions)",
+			sourceRepo: &api.Source{
+				Spec: &api.Source_Repo{
+					Repo: &api.Repo{
+						Kind: api.Kind_CHARTMUSEUM,
+						Auth: &api.Auth{
+							Username: "user",
+							Password: "password",
+						},
+					},
+				},
+			},
+			targetRepo: &api.Target{
+				Spec: &api.Target_Repo{
+					Repo: &api.Repo{
+						Kind: api.Kind_CHARTMUSEUM,
+						Auth: &api.Auth{
+							Username: "user",
+							Password: "password",
+						},
+					},
+				},
+			},
+			entries:        []string{"common"},
+			requiredCharts: []string{"common"},
+			want: []*helmclassic.ChartVersion{
+				{
+					Name:    "common",
+					Version: "1.10.0",
+					URLs:    []string{"charts/common-1.10.0.tgz"},
+				},
+				{
+					Name:    "common",
+					Version: "1.10.1",
+					URLs:    []string{"charts/common-1.10.1.tgz"},
+				},
+			},
+		}, {
+			desc: "sync common (latest version only)",
+			sourceRepo: &api.Source{
+				Spec: &api.Source_Repo{
+					Repo: &api.Repo{
+						Kind: api.Kind_CHARTMUSEUM,
+						Auth: &api.Auth{
+							Username: "user",
+							Password: "password",
+						},
+					},
+				},
+			},
+			targetRepo: &api.Target{
+				Spec: &api.Target_Repo{
+					Repo: &api.Repo{
+						Kind: api.Kind_CHARTMUSEUM,
+						Auth: &api.Auth{
+							Username: "user",
+							Password: "password",
+						},
+					},
+				},
+			},
+			entries:           []string{"common"},
+			requiredCharts:    []string{"common"},
+			latestVersionOnly: true,
+			want: []*helmclassic.ChartVersion{
+				{
+					Name:    "common",
+					Version: "1.10.1",
+					URLs:    []string{"charts/common-1.10.1.tgz"},
+				},
+			},
 		},
 	}
 
@@ -263,7 +336,7 @@ func TestSyncPendingChartsChartMuseum(t *testing.T) {
 			tc.targetRepo.GetRepo().Url = tTester.GetURL()
 
 			// Create new syncer
-			s, err := syncer.New(tc.sourceRepo, tc.targetRepo, syncer.WithSkipDependencies(tc.skipDependencies))
+			s, err := syncer.New(tc.sourceRepo, tc.targetRepo, syncer.WithSkipDependencies(tc.skipDependencies), syncer.WithLatestVersionOnly(tc.latestVersionOnly))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/syncer/syncer.go
+++ b/pkg/syncer/syncer.go
@@ -31,6 +31,7 @@ type Syncer struct {
 	insecure                bool
 	relocateContainerImages bool
 	skipDependencies        bool
+	latestVersionOnly       bool
 
 	// TODO(jdrios): Cache index in local filesystem to speed
 	// up re-runs
@@ -92,6 +93,13 @@ func WithContainerImageRelocation(enable bool) Option {
 func WithSkipDependencies(skipDependencies bool) Option {
 	return func(s *Syncer) {
 		s.skipDependencies = skipDependencies
+	}
+}
+
+// WithLatestVersionOnly configures the syncer to sync only the latest version
+func WithLatestVersionOnly(latestVersionOnly bool) Option {
+	return func(s *Syncer) {
+		s.latestVersionOnly = latestVersionOnly
 	}
 }
 


### PR DESCRIPTION
This PR adds a new CLI flag --latest-version-only to only sync the latest version of each chart