### PR TITLE
chore: bump relok8s version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.59
+	github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.60
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.7.0

--- a/go.sum
+++ b/go.sum
@@ -1177,10 +1177,8 @@ github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:tw
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.58 h1:ngS0+OoyBZXfOFgMqizcmiiLj0s/vBvK4rTNJyijXWk=
-github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.58/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
-github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.59 h1:mU1YO5fCl1DnYgkHJ8GX1DtyNBdVUooZzz04P9i17l0=
-github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.59/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
+github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.60 h1:w+TFfaEwGkF83kLXnNvz48Z1YnKdlB3bbaNhLs+eJDM=
+github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.60/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=


### PR DESCRIPTION
Update the relok8s library to include a fix https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/120 that was altering the sha of the images during an intermediate bundle sync.

Signed-off-by: Miguel Martinez Trivino <mtrivino@vmware.com>