### PR TITLE
chore: update relok8s library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.60
+	github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.4.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.7.0

--- a/go.sum
+++ b/go.sum
@@ -1179,6 +1179,8 @@ github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
 github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.60 h1:w+TFfaEwGkF83kLXnNvz48Z1YnKdlB3bbaNhLs+eJDM=
 github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.60/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
+github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.4.0 h1:6n5mkXBVt/VA3ZtQzaj7M9XNSGVIGReU5IV7Lu1DI1c=
+github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.4.0/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=


### PR DESCRIPTION
Updates relok8s library to a version where credentials fallback is disabled https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/138 


Refs  https://github.com/bitnami-labs/charts-syncer/issues/118