### PR TITLE
chore: update circleci machine used for tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
             - "*"
   test:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     environment:
       KIND_VERSION: "0.8.1"
       KUBECTL_VERSION: "1.18.0"


### PR DESCRIPTION
I got an email from circle ci team notifying this ubuntu 16 image will be deprecated on Tuesday, May 31, 2022.

They referred to [this migrating guide](https://circleci.com/docs/2.0/images/linux-vm/16.04-to-20.04-migration/?mkt_tok=NDg1LVpNSC02MjYAAAGCndaKxNgeWk8CnmHaKSOtscOvesy67d8tIpUx6WHhlORxL770li4WtNDf8XUJGjJrdQoIGyxNjGonUHkACYi8X8jtjXuLw53i7HcmhHT8lXY)