### PR TITLE
chore: validate OCI registry credentials and fix subchart versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/viper v1.8.1
-	github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.4.0
+	github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.5.0
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
 	helm.sh/helm/v3 v3.7.0

--- a/go.sum
+++ b/go.sum
@@ -1177,10 +1177,8 @@ github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:tw
 github.com/vishvananda/netns v0.0.0-20180720170159-13995c7128cc/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vishvananda/netns v0.0.0-20191106174202-0a2b9b5464df/go.mod h1:JP3t17pCcGlemwknint6hfoeCVQrEMVwxRLRjXpq+BU=
 github.com/vishvananda/netns v0.0.0-20200728191858-db3c7e526aae/go.mod h1:DD4vA1DwXk04H54A1oHXtwZmA0grkVMdPxx/VGLCah0=
-github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.60 h1:w+TFfaEwGkF83kLXnNvz48Z1YnKdlB3bbaNhLs+eJDM=
-github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.3.60/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
-github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.4.0 h1:6n5mkXBVt/VA3ZtQzaj7M9XNSGVIGReU5IV7Lu1DI1c=
-github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.4.0/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
+github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.5.0 h1:hdxRHy0gNZQIbuNKsT9RDqn91yOjUEUKPU29q7Ki08Y=
+github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes v0.5.0/go.mod h1:DGpS/YVSEoJzFAmW+3y7gKCmBZsrmmwi2F/DXgDQBIA=
 github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT1RxIR/KWY6phxZiaY1IyutSBfGjNPySAYV4=
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f h1:J9EGpcZtP0E/raorCMxlFGSTBrsSlaDGf3jU/qvAE2c=

--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -215,7 +215,7 @@ func relok8sMoveReq(sourcePath, targetPath, containerRegistry, containerReposito
 					Path: sourcePath,
 				},
 			},
-			Containers: chartsSyncerToRelok8sAuth(sourceAuth),
+			ContainersAuth: chartsSyncerToRelok8sAuth(sourceAuth),
 		},
 		Target: mover.Target{
 			Rules: mover.RewriteRules{
@@ -228,7 +228,7 @@ func relok8sMoveReq(sourcePath, targetPath, containerRegistry, containerReposito
 					Path: targetPath,
 				},
 			},
-			Containers: chartsSyncerToRelok8sAuth(targetAuth),
+			ContainersAuth: chartsSyncerToRelok8sAuth(targetAuth),
 		},
 	}
 
@@ -243,7 +243,7 @@ func relok8sBundleSaveReq(sourcePath, targetPath string, containerSourceAuth *ap
 					Path: sourcePath,
 				},
 			},
-			Containers: chartsSyncerToRelok8sAuth(containerSourceAuth),
+			ContainersAuth: chartsSyncerToRelok8sAuth(containerSourceAuth),
 		},
 		Target: mover.Target{
 			Chart: mover.ChartSpec{
@@ -276,21 +276,21 @@ func relok8sBundleLoadReq(sourcePath, targetPath, containerRegistry, containerRe
 					Path: targetPath,
 				},
 			},
-			Containers: chartsSyncerToRelok8sAuth(containerTargetAuth),
+			ContainersAuth: chartsSyncerToRelok8sAuth(containerTargetAuth),
 		},
 	}
 	return req
 }
 
-// Translates charts syncer authentication settings into relok8s configuration
-func chartsSyncerToRelok8sAuth(containerAuth *api.Containers_ContainerAuth) (relok8sAuth mover.Containers) {
-	if containerAuth != nil {
-		relok8sAuth = mover.Containers{
-			ContainerRepository: mover.ContainerRepository{
-				Username: containerAuth.Username, Password: containerAuth.Password, Server: containerAuth.Registry,
-			},
-		}
+// Translates charts syncer authentication settings into relok8s authentication
+func chartsSyncerToRelok8sAuth(containerAuth *api.Containers_ContainerAuth) (relok8sAuth *mover.ContainersAuth) {
+	if containerAuth == nil {
+		return nil
 	}
 
-	return
+	return &mover.ContainersAuth{
+		Credentials: &mover.OCICredentials{
+			Username: containerAuth.Username, Password: containerAuth.Password, Server: containerAuth.Registry,
+		},
+	}
 }

--- a/pkg/syncer/sync_internal_test.go
+++ b/pkg/syncer/sync_internal_test.go
@@ -171,7 +171,7 @@ func TestRelok8sMoveReq(t *testing.T) {
 					Path: "/tmp/source-dir",
 				},
 			},
-			Containers: mover.Containers{ContainerRepository: mover.ContainerRepository{Server: "sreg", Username: "suser", Password: "spass"}},
+			ContainersAuth: &mover.ContainersAuth{Credentials: &mover.OCICredentials{Server: "sreg", Username: "suser", Password: "spass"}},
 		},
 		Target: mover.Target{
 			Rules: mover.RewriteRules{
@@ -184,7 +184,7 @@ func TestRelok8sMoveReq(t *testing.T) {
 					Path: "/tmp/target-dir",
 				},
 			},
-			Containers: mover.Containers{ContainerRepository: mover.ContainerRepository{Server: "treg", Username: "tuser", Password: "tpass"}},
+			ContainersAuth: &mover.ContainersAuth{Credentials: &mover.OCICredentials{Server: "treg", Username: "tuser", Password: "tpass"}},
 		},
 	}
 	got := relok8sMoveReq("/tmp/source-dir", "/tmp/target-dir", "gcr.io", "my-project/containers",
@@ -203,7 +203,7 @@ func TestRelok8sBundleSaveReq(t *testing.T) {
 					Path: "/tmp/source-dir",
 				},
 			},
-			Containers: mover.Containers{ContainerRepository: mover.ContainerRepository{Server: "reg", Username: "user", Password: "pass"}},
+			ContainersAuth: &mover.ContainersAuth{Credentials: &mover.OCICredentials{Server: "reg", Username: "user", Password: "pass"}},
 		},
 		Target: mover.Target{
 			Chart: mover.ChartSpec{
@@ -239,7 +239,7 @@ func TestRelok8sBundleLoadReq(t *testing.T) {
 					Path: "/tmp/target-dir",
 				},
 			},
-			Containers: mover.Containers{ContainerRepository: mover.ContainerRepository{Server: "reg", Username: "user", Password: "pass"}},
+			ContainersAuth: &mover.ContainersAuth{Credentials: &mover.OCICredentials{Server: "reg", Username: "user", Password: "pass"}},
 		},
 	}
 	got := relok8sBundleLoadReq("/tmp/source-dir", "/tmp/target-dir", "gcr.io", "my-project/containers", &api.Containers_ContainerAuth{Username: "user", Password: "pass", Registry: "reg"})


### PR DESCRIPTION
Updates the relok8s library to add two new features

- Container registry credentials validation https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/146 
- Remove chart dependency references https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/pull/148

The first one will make chart-syncer fail when the `servername` provided is not valid while the second one will make the relocated Helm Charts to not to have a Chart.lock nor dependencies refs in the Chart.yaml. More info on its rationale here https://github.com/vmware-tanzu/asset-relocation-tool-for-kubernetes/issues/142#issue-1124233145