### PR TITLE
Skip change the value.yaml 

### DIFF
--- a/api/config.go
+++ b/api/config.go
@@ -21,12 +21,12 @@ func (c *Config) Validate() error {
 			}
 		case Kind_LOCAL:
 		}
-		if c.GetTarget().GetContainerRegistry() == "" {
-			return errors.Errorf(`"target.containerRegistry" cannot be empty`)
-		}
-		if c.GetTarget().GetContainerRepository() == "" {
-			return errors.Errorf(`"target.containerRepository" cannot be empty`)
-		}
+		// if c.GetTarget().GetContainerRegistry() == "" {
+		// 	return errors.Errorf(`"target.containerRegistry" cannot be empty`)
+		// }
+		// if c.GetTarget().GetContainerRepository() == "" {
+		// 	return errors.Errorf(`"target.containerRepository" cannot be empty`)
+		// }
 	}
 
 	// Authentication

--- a/internal/chart/sync.go
+++ b/internal/chart/sync.go
@@ -14,6 +14,11 @@ import (
 // repo to the target repo
 func ChangeReferences(chartPath, name, version string, source *api.Source, target *api.Target) error {
 	// Update values*.yaml
+	if target.GetContainerRegistry() == "" && target.GetContainerRepository() == "" {
+		// Skip modify value.yaml and readme
+		return nil
+	}
+
 	for _, f := range []string{
 		path.Join(chartPath, ValuesFilename),
 		path.Join(chartPath, ValuesProductionFilename),


### PR DESCRIPTION
Skip change the value.yaml if not set

```
  # The bitnami charts use docker as default container registry. Let's switch
  # to one of their mirrors to ensure the container references reallocation works.
  #
  # NOTE: This does not reallocate container artifacts, actually, but their
  #       references in the chart.
  containerRegistry: gcr.io
  containerRepository: bitnami-containers
```

reslove : https://github.com/bitnami-labs/charts-syncer/issues/104