### PR TITLE
chore: update testing components version and charts-syncer flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
     environment:
       KIND_VERSION: "0.8.1"
       KUBECTL_VERSION: "1.18.0"
-      HELM_VERSION: "3.2.3"
+      HELM_VERSION: "3.8.1"
       DEBUG_MODE: "true"
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,8 +60,8 @@ jobs:
     machine:
       image: ubuntu-2004:202201-02
     environment:
-      KIND_VERSION: "0.8.1"
-      KUBECTL_VERSION: "1.18.0"
+      KIND_VERSION: "0.12.0"
+      KUBECTL_VERSION: "1.22.0"
       HELM_VERSION: "3.8.1"
       DEBUG_MODE: "true"
     steps:

--- a/test/run-charts-syncer.sh
+++ b/test/run-charts-syncer.sh
@@ -10,4 +10,4 @@ ROOT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd)"
 ## Wait for chartmuseum service (Timeout in 30s)
 wait-for-port --state=inuse 8080
 
-/tmp/dist/charts-syncer --config ${ROOT_DIR}/test/test-config.yaml sync --from-date 2020-10-01
+/tmp/dist/charts-syncer --config ${ROOT_DIR}/test/test-config.yaml sync --latest-version-only


### PR DESCRIPTION
Update old version of Helm, Kind, and Kubectl used for testing.
Additionally, just sync the latest version of the testing app (ghost) instead of syncing all available versions from specificdate.