### PR TITLE
Replace gcr.io/bitnami-containers by docker.io/bitnami

### DIFF
--- a/examples/chartmuseum.yaml
+++ b/examples/chartmuseum.yaml
@@ -22,8 +22,8 @@ target:
   #
   # NOTE: This does not reallocate container artifacts, actually, but their
   #       references in the chart.
-  containerRegistry: gcr.io
-  containerRepository: bitnami-containers
+  containerRegistry: docker.io
+  containerRepository: bitnami
   # Chartmuseum running via:
   #
   # chartmuseum --basic-auth-user admin --basic-auth-pass admin \

--- a/examples/local.yaml
+++ b/examples/local.yaml
@@ -22,8 +22,8 @@ target:
   #
   # NOTE: This does not reallocate container artifacts, actually, but their
   #       references in the chart.
-  containerRegistry: gcr.io
-  containerRepository: bitnami-containers
+  containerRegistry: docker.io
+  containerRepository: bitnami
   repo:
     kind: LOCAL
     path: ./local-repo

--- a/test/run-verifications.sh
+++ b/test/run-verifications.sh
@@ -7,7 +7,7 @@ set -o pipefail
 # Constants
 ROOT_DIR="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null && pwd)"
 FAILED_TEST=0
-EXPECTED_REGISTRY='gcr.io/bitnami-containers'
+EXPECTED_REGISTRY='docker.io/bitnami'
 
 ## Check that Ghost deployment is using the expected registry
 ghostImage=$(kubectl get pods --selector=app.kubernetes.io/name=ghost -ojsonpath='{.items[0].spec.containers[0].image}')

--- a/test/test-config.yaml
+++ b/test/test-config.yaml
@@ -6,8 +6,8 @@ source:
     kind: "HELM"
     url: "https://charts.bitnami.com/bitnami"
 target:
-  containerRegistry: "gcr.io"
-  containerRepository: "bitnami-containers"
+  containerRegistry: "docker.io"
+  containerRepository: "bitnami"
   repo:
     kind: "CHARTMUSEUM"
     url: "http://127.0.0.1:8080"


### PR DESCRIPTION
Signed-off-by: Carlos Rodriguez Hernandez <carlosrh@vmware.com>

Replace the deprecated `gcr.io/bitnami-containers` by `docker.io/bitnami`