### PR TITLE
Fixed an issue with incorrect use of the chartmuseum API, And update the test cace

### DIFF
--- a/pkg/client/repo/chartmuseum/chartmuseum.go
+++ b/pkg/client/repo/chartmuseum/chartmuseum.go
@@ -56,7 +56,7 @@ func NewRaw(u *url.URL, user string, pass string, c cache.Cacher, insecure bool)
 // GetUploadURL returns the URL to upload a chart
 func (r *Repo) GetUploadURL() string {
 	u := *r.url
-	u.Path = "/api/charts"
+	u.Path += "/api/charts"
 	return u.String()
 }
 

--- a/pkg/client/repo/chartmuseum/chartmuseumtester.go
+++ b/pkg/client/repo/chartmuseum/chartmuseumtester.go
@@ -19,7 +19,7 @@ var (
 	cmRegex           = regexp.MustCompile(`(?m)\/charts\/(.*.tgz)`)
 	username   string = "user"
 	password   string = "password"
-	repositroy string = "myrepo"
+	repository string = "myrepo"
 )
 
 // RepoTester allows to unit test each repo implementation
@@ -54,7 +54,7 @@ func NewTester(t *testing.T, repo *api.Repo, emptyIndex bool, indexFile string) 
 		indexFile:  indexFile,
 	}
 	s := httptest.NewServer(tester)
-	u, err := url.Parse(fmt.Sprintf("%s/%s", s.URL, repositroy))
+	u, err := url.Parse(fmt.Sprintf("%s/%s", s.URL, repository))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/repo/chartmuseum/chartmuseumtester.go
+++ b/pkg/client/repo/chartmuseum/chartmuseumtester.go
@@ -1,6 +1,7 @@
 package chartmuseum
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -15,9 +16,10 @@ import (
 )
 
 var (
-	cmRegex         = regexp.MustCompile(`(?m)\/charts\/(.*.tgz)`)
-	username string = "user"
-	password string = "password"
+	cmRegex           = regexp.MustCompile(`(?m)\/charts\/(.*.tgz)`)
+	username   string = "user"
+	password   string = "password"
+	repositroy string = "myrepo"
 )
 
 // RepoTester allows to unit test each repo implementation
@@ -52,7 +54,7 @@ func NewTester(t *testing.T, repo *api.Repo, emptyIndex bool, indexFile string) 
 		indexFile:  indexFile,
 	}
 	s := httptest.NewServer(tester)
-	u, err := url.Parse(s.URL)
+	u, err := url.Parse(fmt.Sprintf("%s/%s", s.URL, repositroy))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,20 +78,20 @@ func (rt *RepoTester) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Handle recognized requests.
-	if base, chart := path.Split(r.URL.Path); base == "/api/charts/" && r.Method == "GET" {
+	if base, chart := path.Split(r.URL.Path); base == "/myrepo/api/charts/" && r.Method == "GET" {
 		rt.GetChart(w, r, chart)
 		return
 	}
-	if r.URL.Path == "/api/charts" && r.Method == "POST" {
+	if r.URL.Path == "/myrepo/api/charts" && r.Method == "POST" {
 		rt.PostChart(w, r)
 		return
 	}
-	if r.URL.Path == "/index.yaml" && r.Method == "GET" {
+	if r.URL.Path == "/myrepo/index.yaml" && r.Method == "GET" {
 		rt.GetIndex(w, r, rt.emptyIndex, rt.indexFile)
 		return
 	}
 	if cmRegex.Match([]byte(r.URL.Path)) && r.Method == "GET" {
-		chartPackage := strings.Split(r.URL.Path, "/")[2]
+		chartPackage := strings.Split(r.URL.Path, "/")[3]
 		rt.GetChartPackage(w, r, chartPackage)
 		return
 	}


### PR DESCRIPTION
In fact, The following APIs are all prefixed of chartmuseum

Helm Chart Repository
- `GET /:repo/index.yaml` - retrieved when you run `helm repo add chartmuseum http://localhost:8080/`
- `GET /:repo/charts/mychart-0.1.0.tgz` - retrieved when you run `helm install chartmuseum/mychart`
- `GET /:repo/charts/mychart-0.1.0.tgz.prov` - retrieved when you run `helm install` with the `--verify` flag

Chart Manipulation
- `POST /:repo/api/charts` - upload a new chart version
- `POST /:repo/api/prov` - upload a new provenance file
- `DELETE /:repo/api/charts/<name>/<version>` - delete a chart version (and corresponding provenance file)
- `GET /:repo/api/charts` - list all charts
- `GET /:repo/api/charts/<name>` - list all versions of a chart
- `GET /:repo/api/charts/<name>/<version>` - describe a chart version
- `GET /:repo/api/charts/<name>/<version>/templates` - get chart template
- `GET /:repo/api/charts/<name>/<version>/values` - get chart values
- `HEAD /:repo/api/charts/<name>` - check if chart exists (any versions)
- `HEAD /:repo/api/charts/<name>/<version>` - check if chart version exists

When using `source.repo.kind: CHARTMUSEUM`, We used the `source.repo.url` directly, So It's right——`https://chart.example.com/myrepo/charts/etcd-4.8.0.tgz`

But In `target.repo.kind: CHARTMUSEUM`, We removed URL.Path,So we got the wrong URL——`https://chart.example.com/api/charts`

Now I have fixed this problem and updated the test case @jiparis 
