### PR TITLE
Rewrite implementation of Has() method in oci.Repo

### DIFF
--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -272,7 +272,9 @@ func (r *Repo) Has(name string, version string) (bool, error) {
 	defer cancel()
 
 	u := *r.url
-	// Form API endpoint URL from repo url
+	// Form API endpoint URL from repo url as per the specification:
+	// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#checking-if-content-exists-in-the-registry
+	// A successful request should return 200 OK.
 	u.Path = path.Join("v2", u.Path, name, "manifests", version)
 	req, err := http.NewRequestWithContext(ctx, "HEAD", u.String(), nil)
 	if err != nil {

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -274,7 +274,7 @@ func (r *Repo) Has(name string, version string) (bool, error) {
 	u := *r.url
 	// Form API endpoint URL from repo url as per the specification:
 	// https://github.com/opencontainers/distribution-spec/blob/main/spec.md#checking-if-content-exists-in-the-registry
-	// A successful request should return 200 OK.
+	// The request should return 200 OK if the manifest exists.
 	u.Path = path.Join("v2", u.Path, name, "manifests", version)
 	req, err := http.NewRequestWithContext(ctx, "HEAD", u.String(), nil)
 	if err != nil {

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -268,14 +268,35 @@ func (r *Repo) Fetch(name string, version string) (string, error) {
 
 // Has checks if a repo has a specific chart
 func (r *Repo) Has(name string, version string) (bool, error) {
-	versions, err := r.ListChartVersions(name)
+	ctx, cancel := context.WithTimeout(context.Background(), getTimeout)
+	defer cancel()
+
+	u := *r.url
+	// Form API endpoint URL from repo url
+	u.Path = path.Join("v2", u.Path, name, "manifests", version)
+	req, err := http.NewRequestWithContext(ctx, "HEAD", u.String(), nil)
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	for _, v := range versions {
-		if v == version {
-			return true, nil
-		}
+
+	req.Header.Set("Accept", ImageManifestMediaType)
+	if r.username != "" && r.password != "" {
+		req.SetBasicAuth(r.username, r.password)
+	}
+
+	client := utils.DefaultClient
+	if r.insecure {
+		client = utils.InsecureClient
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusOK {
+		return true, nil
 	}
 	return false, nil
 }

--- a/pkg/client/repo/oci/ocitester.go
+++ b/pkg/client/repo/oci/ocitester.go
@@ -187,7 +187,7 @@ func (rt *RepoTester) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rt.GetChartPackage(w, r, name, digest)
 		return
 	}
-	if ociTagManifestRegex.Match([]byte(r.URL.Path)) && r.Method == "GET" {
+	if ociTagManifestRegex.Match([]byte(r.URL.Path)) && (r.Method == "GET" || r.Method == "HEAD") {
 		testBasicAuth(rt.t, r)
 		name := strings.Split(r.URL.Path, "/")[4]
 		version := strings.Split(r.URL.Path, "/")[6]

--- a/pkg/client/repo/oci/ocitester.go
+++ b/pkg/client/repo/oci/ocitester.go
@@ -187,7 +187,12 @@ func (rt *RepoTester) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		rt.GetChartPackage(w, r, name, digest)
 		return
 	}
-	if ociTagManifestRegex.Match([]byte(r.URL.Path)) && (r.Method == "GET" || r.Method == "HEAD") {
+	if ociTagManifestRegex.Match([]byte(r.URL.Path)) && r.Method == "HEAD" {
+		testBasicAuth(rt.t, r)
+		rt.HeadManifest200(w)
+		return
+	}
+	if ociTagManifestRegex.Match([]byte(r.URL.Path)) && r.Method == "GET" {
 		testBasicAuth(rt.t, r)
 		name := strings.Split(r.URL.Path, "/")[4]
 		version := strings.Split(r.URL.Path, "/")[6]
@@ -243,6 +248,11 @@ func (rt *RepoTester) GetTagsList(w http.ResponseWriter, r *http.Request, name s
 		rt.t.Fatal(err)
 	}
 	w.Write(tagsList)
+}
+
+// HeadManifest404 return if a manifests exists or not
+func (rt *RepoTester) HeadManifest200(w http.ResponseWriter) {
+	w.WriteHeader(200)
 }
 
 // HeadManifest404 return if a manifests exists or not

--- a/pkg/client/repo/oci/ocitester.go
+++ b/pkg/client/repo/oci/ocitester.go
@@ -250,7 +250,7 @@ func (rt *RepoTester) GetTagsList(w http.ResponseWriter, r *http.Request, name s
 	w.Write(tagsList)
 }
 
-// HeadManifest404 return if a manifests exists or not
+// HeadManifest200 return if a manifests exists or not
 func (rt *RepoTester) HeadManifest200(w http.ResponseWriter) {
 	w.WriteHeader(200)
 }


### PR DESCRIPTION
For our use case, we want to sync Helm charts between Sonatype Nexus, a classic Helm repo, to Harbor, an OCI registry. This took over three hours to complete, which lead me to investigate what it was doing that was taking so long.

For every version of a chart that it finds on Nexus, it checks if that version already exists on Harbor. To do that, it lists all of that chart’s versions by downloading every single version that exists in Harbor for that chart. For one of our charts, we have 611 versions in Nexus. charts-syncer was doing 611 * 611 = 373.321 GET calls to Harbor. It spent three hours just indexing the charts.

I rewrote the implementation of the Has() method in oci.Repo so that it instead performs a single HEAD request to check if the version is present on the registry. That seems to work just fine for us.

The tests fail because the test server doesn't handle HEAD requests, and I couldn't figure out how to fix that. Changing it to a GET request fixes the test, but that's not the most optimal choice performance-wise.