### PR TITLE
Properly discover existing image in OCI target

### DIFF
--- a/pkg/client/repo/oci/oci_test.go
+++ b/pkg/client/repo/oci/oci_test.go
@@ -47,8 +47,18 @@ func TestFetch(t *testing.T) {
 }
 
 func TestHas(t *testing.T) {
-	c := oci.PrepareHttpServer(t, ociRepo)
-	has, err := c.Has("kafka", "12.2.1")
+	oci.PrepareOciServer(t, ociRepo)
+	c := oci.PrepareTest(t, ociRepo)
+
+	chartMetadata := &chart.Metadata{
+		Name:    "apache",
+		Version: "7.3.15",
+	}
+	if err := c.Upload("../../../../testdata/apache-7.3.15.tgz", chartMetadata); err != nil {
+		t.Fatal(err)
+	}
+
+	has, err := c.Has(chartMetadata.Name, chartMetadata.Version)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When using ghcr.io as an OCI target then charts-syncer would always overwrite an already existing chart because ghcr.io requires a client to retrieve a bearer token before making any requests against it. This is also true when basic auth credentials are provided. The `Repo#Has` method would always fail in that case because it can't handle 401 responses.

I exchanged the code in the `Has` method to use the go-containerregistry client instead that properly handles authentication.

# Before

```
$ go run main.go sync --latest-version-only
I0503 18:44:41.867762 3171500 sync.go:49] Looking for the default config charts-syncer.yaml
I0503 18:44:42.448242 3171500 sync.go:47] There is 1 chart out of sync!
I0503 18:44:42.448269 3171500 sync.go:55] Syncing "grafana-6.56.1" chart...
```

# After

```
$ go run main.go sync --latest-version-only
I0503 18:44:16.945449 3168464 sync.go:49] Looking for the default config charts-syncer.yaml
I0503 18:44:17.933216 3168464 sync.go:49] There are no charts out of sync!
```