### PR TITLE
github-actions: Add gchat notification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,18 +1,19 @@
 name: CI
 on:
   workflow_dispatch:
-  push: 
+  push:
     branches:
        - v2
   pull_request:
     branches:
       - v2
     types:
-      - assigned 
-      - opened 
-      - synchronize 
+      - assigned
+      - opened
+      - synchronize
       - reopened
-
+# Remove all permissions by default
+permissions: {}
 env:
   KIND_VERSION: "0.12.0"
   KUBECTL_VERSION: "1.22.0"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,11 @@ on:
   push:
     tags:
       - "v*.*.*"
-
+# Remove all permissions by default
+permissions: {}
 jobs:
   release:
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -31,3 +31,15 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  # If the CI Pipeline does not succeed we should notify the interested agents
+  notify:
+    name: Send notification
+    needs:
+      - release
+    if: ${{ always() && needs.release.result == 'failure' }}
+    uses: bitnami/support/.github/workflows/gchat-notification.yml@main
+    with:
+      workflow: ${{ github.workflow }}
+      job-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    secrets:
+      webhook-url: ${{ secrets.GCHAT_CONTENT_ALERTS_WEBHOOK_URL }}


### PR DESCRIPTION
### Description of the change

This PR adds GChat notifications to the CD pipeline.

When the pipeline fails, it will notify the team with a message using the gchat-notification worflow from bitnami/support

### Possible drawbacks

None known.
