### PR TITLE
chore: remove gcr image publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,12 +14,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Unshallow
         run: git fetch --prune --unshallow
-      - name: Docker login to GCR
-        uses: docker/login-action@v3
-        with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GCR_JSON_KEY }}
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -28,6 +22,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,17 +10,6 @@ builds:
     binary: charts-syncer
     ldflags:
       - -X main.version={{.Version}}
-dockers:
-  -
-    ids:
-      - release
-    dockerfile: Dockerfile
-    image_templates:
-      - "gcr.io/bitnami-labs/charts-syncer:{{ .Tag }}"
-      - "gcr.io/bitnami-labs/charts-syncer:latest"
-    build_flag_templates:
-      - "--build-arg"
-      - "IMAGE_VERSION={{ .Tag }}"
 archives:
   - format: tar.gz
     name_template: >-

--- a/deployment/cronjob.yaml
+++ b/deployment/cronjob.yaml
@@ -13,7 +13,7 @@ spec:
           containers:
           - name: charts-syncer
             imagePullPolicy: Always
-            image: gcr.io/bitnami-labs/charts-syncer:v0.14.0
+            image: bitnami/charts-syncer:v2.0.2
             args: ["sync", "--config", "/charts-syncer.yaml", "-v", "4", "--latest-version-only"]
             env:
               # Helm Chart source repository credentials

--- a/deployment/kustomization.yaml
+++ b/deployment/kustomization.yaml
@@ -5,10 +5,10 @@ namespace: charts-syncer
 commonLabels:
   app: charts-syncer
 images:
-  - name: gcr.io/bitnami-labs/charts-syncer
+  - name: bitnami/charts-syncer
     # Set this value to the latest release
     # https://github.com/bitnami/charts-syncer/releases
-    newTag: v0.20.1
+    newTag: v2.0.2
 
 resources:
   - cronjob.yaml
@@ -27,7 +27,7 @@ secretGenerator:
     envs:
       - config/secrets.env
     # You can also generate credentials from a file using files: directive
-    # useful if you are loading creds from a GCR/ACR service account p12/json file
+    # useful if you are loading creds from a GAR/ACR service account p12/json file
     # files:
-    #  - target-password=config/my_gcr_creds.json
+    #  - target-password=config/my_gar_creds.json
 


### PR DESCRIPTION
Stop publishing the chart-syncer image to GCR since Google is deprecating that service.

The charts-syncer images will keep being published at https://hub.docker.com/r/bitnami/charts-syncer