### PR TITLE
Update kubernetes cronjob deployment enhancing security

### DIFF
--- a/deployment/cronjob.yaml
+++ b/deployment/cronjob.yaml
@@ -10,10 +10,15 @@ spec:
     spec:
       template:
         spec:
+          securityContext:
+            fsGroup: 1001
+            fsGroupChangePolicy: OnRootMismatch
+            supplementalGroups: []
+            sysctls: []
           containers:
           - name: charts-syncer
             imagePullPolicy: Always
-            image: bitnami/charts-syncer:v2.0.2
+            image: bitnami/charts-syncer:2.1.1
             args: ["sync", "--config", "/charts-syncer.yaml", "-v", "4", "--latest-version-only"]
             env:
               # Helm Chart source repository credentials
@@ -70,12 +75,31 @@ spec:
                   secretKeyRef:
                     name: charts-syncer-credentials
                     key: TARGET_CONTAINERS_AUTH_REGISTRY
+            securityContext:
+              runAsUser: 1001
+              runAsGroup: 1001
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                - ALL
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seLinuxOptions: {}
+              seccompProfile:
+                type: RuntimeDefault
             volumeMounts:
               - name: config
                 mountPath: /charts-syncer.yaml
                 subPath: charts-syncer.yaml
+              - name: empty-dir
+                mountPath: /tmp
+              - name: empty-dir
+                mountPath: /.charts-syncer
           restartPolicy: OnFailure
           volumes:
+            - name: empty-dir
+              emptyDir: {}
             - name: config
               configMap:
                 name: charts-syncer-config

--- a/deployment/kustomization.yaml
+++ b/deployment/kustomization.yaml
@@ -8,7 +8,7 @@ images:
   - name: bitnami/charts-syncer
     # Set this value to the latest release
     # https://github.com/bitnami/charts-syncer/releases
-    newTag: v2.0.2
+    newTag: 2.1.1
 
 resources:
   - cronjob.yaml


### PR DESCRIPTION
### Description of the change

Update the kubernetes cronjob under `./deployment` with the following changes:

- Update image tag to current latest version 2.1.1
- Add container and pod security context removing privileges
- Add emptyDir volume and configure `readOnlyRootFilesystem`