### PR TITLE
chore: improve dry-run output

### DIFF
--- a/pkg/syncer/sync.go
+++ b/pkg/syncer/sync.go
@@ -10,7 +10,6 @@ import (
 	"github.com/juju/errors"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/log"
 	helmchart "helm.sh/helm/v3/pkg/chart"
-	"k8s.io/klog"
 )
 
 // ErrNoChartsToSync is returned when there are no charts to sync
@@ -18,19 +17,17 @@ var ErrNoChartsToSync = errors.New("no charts to sync")
 
 func (s *Syncer) syncChart(ch *Chart, l log.SectionLogger) error {
 	id := fmt.Sprintf("%s-%s", ch.Name, ch.Version)
-	klog.Infof("Syncing %q chart...", id)
 
-	klog.V(3).Infof("Processing %q chart...", id)
 	outdir, err := os.MkdirTemp("", "charts-syncer")
 	if err != nil {
-		klog.Errorf("unable to create output directory for %q chart: %+v", id, err)
+		l.Errorf("unable to create output directory for %q chart: %+v", id, err)
 		return errors.Trace(err)
 	}
 	defer os.RemoveAll(outdir)
 
 	workdir, err := os.MkdirTemp("", "charts-syncer")
 	if err != nil {
-		klog.Errorf("unable to create work directory for %q chart: %+v", id, err)
+		l.Errorf("unable to create work directory for %q chart: %+v", id, err)
 		return errors.Trace(err)
 	}
 	defer os.RemoveAll(workdir)
@@ -52,14 +49,12 @@ func (s *Syncer) syncChart(ch *Chart, l log.SectionLogger) error {
 	}
 
 	if s.dryRun {
-		klog.Infof("dry-run: Uploading %q chart", id)
+		l.Warnf("Dry-run mode is enabled. Upload of chart %q is being skipped.", id)
 		return nil
 	}
 
-	klog.V(3).Infof("Uploading %q chart...", id)
-
 	if err := s.cli.dst.Unwrap(wrappedChartPath, metadata, config.WithLogger(l), config.WithWorkDir(workdir), config.WithSkipImages(s.skipImages)); err != nil {
-		klog.Errorf("unable to upload %q chart: %+v", id, err)
+		l.Errorf("unable to upload %q chart: %+v", id, err)
 		return errors.Trace(err)
 	}
 	return nil
@@ -94,15 +89,15 @@ func (s *Syncer) SyncPendingCharts(names ...string) error {
 	} else if len(charts) == 1 {
 		msg = fmt.Sprintf("There is %d chart out of sync!", len(charts))
 	} else {
-		klog.Info("There are no charts out of sync!")
+		s.logger.Infof("There are no charts out of sync!")
 		return ErrNoChartsToSync
 	}
 
-	klog.Info(msg)
+	s.logger.Infof(msg)
 
 	for i, ch := range charts {
 		id := fmt.Sprintf("%s-%s", ch.Name, ch.Version)
-		if err := s.logger.Section(fmt.Sprintf("Syncing %q chart (%d/%d)", id, i+1, len(charts)), func(l log.SectionLogger) error {
+		if err := s.logger.Section(fmt.Sprintf("==> Syncing %q chart (%d/%d)", id, i+1, len(charts)), func(l log.SectionLogger) error {
 			return s.syncChart(ch, l)
 		}); err != nil {
 			s.logger.Warnf("Failed syncing %q chart: %v", id, err)


### PR DESCRIPTION
### Description of the change

This PR improves the output of the tool when the --dry-run mode is active. Previously, there was not any clear indication.

### Applicable issues

  - fixes https://github.com/bitnami/charts-syncer/issues/244

### Additional information

Example of output:

```
 »  Syncing charts
    ✔  Chart list loaded
    ✔  There is 1 chart out of sync!
    »  ==> Syncing "wiz-kubernetes-integration-0.2.97" chart (1/1)
       »  Wrapping Helm chart "/Users/tompizmor/.charts-syncer/fce61cd82916aced85f328cb299809fb4b85744f/wiz-kubernetes-integration-0.2.97.tgz"
          ✔  Helm chart uncompressed to "/var/folders/ty/f9vsrvsx0bl3bh0skkfqrfnh0000gn/T/charts-syncer1668339046/charts-syncer2988317351/dt-wrap2671875946"
          ✔  Images.lock file written to "/var/folders/ty/f9vsrvsx0bl3bh0skkfqrfnh0000gn/T/charts-syncer1668339046/charts-syncer2988317351/wrap/chart/Images.lock"
          ⚠️  No images found in Images.lock
          ✔  Compressed into "/var/folders/ty/f9vsrvsx0bl3bh0skkfqrfnh0000gn/T/charts-syncer1668339046/wraps/wiz-kubernetes-integration-0.2.97.wrap.tgz"
       ⚠️  Dry-run mode is enabled. Upload of chart "wiz-kubernetes-integration-0.2.97" is being skipped.
 🎉  Charts synced successfully
```
