### PR TITLE
[github-actions] Release bitnami/charts-syncer image from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: Release
 
 on:
   push:
@@ -10,12 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     env:
       dockerhub_image_name: docker.io/bitnami/charts-syncer
-      ghcr_image_name: ghcr.io/bitnami-labs/charts-syncer
+      ghcr_image_name: ghcr.io/bitnami/charts-syncer
     steps:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Unshallow
         run: git fetch --prune --unshallow
+      # Obtain the release version from the tag without the 'v' prefix
+      - name: Write release version
+        run: |
+          VERSION_TAG=${GITHUB_REF_NAME#v}
+          echo Version: $VERSION_TAG
+          echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_ENV
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
@@ -23,9 +29,6 @@ jobs:
       # Setup env for multi-arch builds
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2.0.0
-        with:
-          image: tonistiigi/binfmt:latest
-          platforms: arm64,arm
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.0.0
       # Build
@@ -55,15 +58,21 @@ jobs:
           images: |
             ${{ env.dockerhub_image_name }}
             ${{ env.ghcr_image_name }}
+          # Image tags: 'latest', '2' and the tagged version without the 'v' prefix
           tags: |
+            type=raw,value=2
             type=raw,value=${{ env.VERSION_TAG }}
             type=raw,value=latest
       - name: Build and push image
         id: docker_build
         uses: docker/build-push-action@v3.2.0
+        env:
+          # Disable attestation to prevent 'unknown/unknown' artifacts in GHCR
+          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
+          labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-
+    env:
+      dockerhub_image_name: docker.io/bitnami/charts-syncer
+      ghcr_image_name: ghcr.io/bitnami-labs/charts-syncer
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -18,6 +20,15 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '^1.25'
+      # Setup env for multi-arch builds
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.0.0
+        with:
+          image: tonistiigi/binfmt:latest
+          platforms: arm64,arm
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
+      # Build
       - name: Release
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -25,3 +36,34 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Build & Publish multi-arch image
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2.0.0
+        with:
+          username: ${{ secrets.BITNAMI_USERNAME }}
+          password: ${{ secrets.BITNAMI_PASSWORD }}
+      - name: Login to GHRC
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract image metadata (tags, labels)
+        id: metadata
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: |
+            ${{ env.dockerhub_image_name }}
+            ${{ env.ghcr_image_name }}
+          tags: |
+            type=raw,value=${{ env.VERSION_TAG }}
+            type=raw,value=latest
+      - name: Build and push image
+        id: docker_build
+        uses: docker/build-push-action@v3.2.0
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64,linux/arm
+          push: true
+          tags: ${{ steps.metadata.outputs.tags }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-qemu-action@v2.0.0
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2.0.0
-      # Build
+      # Build binaries
       - name: Release
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ARG APP_VERSION
 ENV OS_ARCH="${TARGETARCH:-amd64}"
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder ./charts-syncer /opt/bitnami/charts-syncer/bin/charts-syncer
+COPY dist/release_linux_${OS_ARCH}*/charts-syncer /opt/bitnami/charts-syncer/bin/charts-syncer
 COPY --from=builder /rootfs /
 
 ENV APP_VERSION="${APP_VERSION}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,13 @@ RUN mkdir -p /rootfs/tmp && mkdir /rootfs/.charts-syncer && chmod g+rwX /rootfs/
 FROM scratch
 
 ARG TARGETARCH
-ARG APP_VERSION
 ENV OS_ARCH="${TARGETARCH:-amd64}"
 
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY dist/release_linux_${OS_ARCH}*/charts-syncer /opt/bitnami/charts-syncer/bin/charts-syncer
 COPY --from=builder /rootfs /
 
-ENV APP_VERSION="${APP_VERSION}" \
-    BITNAMI_APP_NAME="charts-syncer" \
-    PATH="/opt/bitnami/charts-syncer/bin:$PATH"
+ENV PATH="/opt/bitnami/charts-syncer/bin:$PATH"
 
 USER 1001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,29 @@
-FROM bitnami/minideb:buster as build
+# Copyright Broadcom, Inc. All Rights Reserved.
+# SPDX-License-Identifier: APACHE-2.0
+
+FROM docker.io/bitnami/minideb:bookworm AS builder
+
+SHELL ["/bin/bash", "-o", "errexit", "-o", "nounset", "-o", "pipefail", "-c"]
+
 RUN install_packages ca-certificates
-RUN mkdir /workdir
+RUN mkdir -p /rootfs/tmp && mkdir /rootfs/.charts-syncer && chmod g+rwX /rootfs/tmp /rootfs/.charts-syncer
+
+######
 
 FROM scratch
-ARG IMAGE_VERSION
-ENV IMAGE_VERSION=${IMAGE_VERSION}
-COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-# Workaround to have a /tmp folder in the scratch container
-COPY --from=build /workdir /tmp
-COPY ./charts-syncer /
-ENTRYPOINT [ "/charts-syncer" ]
+
+ARG TARGETARCH
+ARG APP_VERSION
+ENV OS_ARCH="${TARGETARCH:-amd64}"
+
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder ./charts-syncer /opt/bitnami/charts-syncer/bin/charts-syncer
+COPY --from=builder /rootfs /
+
+ENV APP_VERSION="${APP_VERSION}" \
+    BITNAMI_APP_NAME="charts-syncer" \
+    PATH="/opt/bitnami/charts-syncer/bin:$PATH"
+
+USER 1001
+
+ENTRYPOINT [ "charts-syncer" ]


### PR DESCRIPTION
### Description of the change

Update the release.yaml workflow to include the build and publish of the bitnami/charts-syncer image directly from this repository, so it is not affected by the upcoming changes to the catalog.

### Benefits

The bitnami/charts-syncer image will be available in the same registry as usual.

### Possible drawbacks

Minor differences between the current image and the one generated by this process, e.g. path /opt/bitnami/charts-syncer/licenses and /opt/bitnami/charts-syncer/.spdx-charts-syncer.spdx will disappear as this build process does not generate those files.

- FIxes https://github.com/bitnami/charts-syncer/issues/257
