### PR TITLE
Update distribution-tooling-for-helm to version v0.4.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.10.0
-	github.com/vmware-labs/distribution-tooling-for-helm v0.4.8
+	github.com/vmware-labs/distribution-tooling-for-helm v0.4.9
 	google.golang.org/protobuf v1.36.6
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.18.6

--- a/go.sum
+++ b/go.sum
@@ -695,6 +695,8 @@ github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnn
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
 github.com/vmware-labs/distribution-tooling-for-helm v0.4.8 h1:HmvCAlnXaQ3XC38UETtWZvDDGPYqRVjHTiULzJWtj7Q=
 github.com/vmware-labs/distribution-tooling-for-helm v0.4.8/go.mod h1:+BViIwNOcMGJnxYQWXJRBKt3OLuQ06VMnxWxuztIP0c=
+github.com/vmware-labs/distribution-tooling-for-helm v0.4.9 h1:+0MA2i3jPZ5V7bc3SJsy2Mi81Z9py6iFKkNTLGPnmd8=
+github.com/vmware-labs/distribution-tooling-for-helm v0.4.9/go.mod h1:+BViIwNOcMGJnxYQWXJRBKt3OLuQ06VMnxWxuztIP0c=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/vmware-tanzu/carvel-imgpkg v0.38.3 h1:vVnqCPFEZ2NQcoTywg/va91qRyCuu46wBYAETqoyez4=


### PR DESCRIPTION
### Description of the change

This PR updates the version of the distribution-tooling-for-helm dependency to its latest version (v0.4.9)
