### PR TITLE
Clean interfaces and remove unused methods

### DIFF
--- a/cmd/sync_test.go
+++ b/cmd/sync_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"os"
 	"slices"
+	"strings"
 	"testing"
 	"text/template"
 
@@ -89,7 +91,6 @@ func TestSync(t *testing.T) {
 
 func prepareSourceRepo(_ context.Context, t *testing.T) {
 	oci.PrepareOCIServer(context.Background(), t, ociSourceRepo)
-	cs := oci.PrepareTest(t, ociSourceRepo)
 
 	charts := []struct {
 		Name    string
@@ -106,9 +107,16 @@ func prepareSourceRepo(_ context.Context, t *testing.T) {
 		}
 		// Upload chart to source repo
 		chartPath := fmt.Sprintf("../testdata/%s-%s.tgz", c.Name, c.Version)
-		if err := cs.Upload(chartPath, chartMetadata); err != nil {
+		u, err := url.Parse(ociSourceRepo.Url)
+		if err != nil {
 			t.Fatal(err)
 		}
+		// helm replaces plus(+) characters with underscores(_) in the tag (version)
+		chartRef := fmt.Sprintf("%s%s/%s:%s", u.Host, u.Path, chartMetadata.Name, strings.ReplaceAll(chartMetadata.Version, "+", "_"))
+		if err := oci.PushChartToOCI(chartPath, chartMetadata, chartRef); err != nil {
+			t.Fatal(err)
+		}
+
 	}
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -17,14 +17,11 @@ type ChartsReader interface {
 	ListChartVersions(name string) ([]string, error)
 	Has(name string, version string) (bool, error)
 	GetChartDetails(name string, version string) (*types.ChartDetails, error)
-	// Reload reloads or refresh the client-side data, in case it needs it
-	Reload() error
 }
 
 // ChartsWriter defines the methods that a WriteOnly chart or bundle client should implement.
 type ChartsWriter interface {
 	GetUploadURL() string
-	Upload(filepath string, metadata *chart.Metadata) error
 }
 
 // ChartsReaderWriter defines the methods that a chart or bundle client should implement

--- a/pkg/client/repo/chartmuseum/chartmuseum.go
+++ b/pkg/client/repo/chartmuseum/chartmuseum.go
@@ -2,24 +2,14 @@
 package chartmuseum
 
 import (
-	"bytes"
-	"io"
-	"mime/multipart"
-	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 
 	"github.com/bitnami/charts-syncer/pkg/client/repo/helmclassic"
 
-	"github.com/juju/errors"
-	"k8s.io/klog"
-
 	"github.com/bitnami/charts-syncer/api"
 	"github.com/bitnami/charts-syncer/internal/cache"
-	"github.com/bitnami/charts-syncer/internal/utils"
 	"github.com/bitnami/charts-syncer/pkg/client/types"
-	"helm.sh/helm/v3/pkg/chart"
+	"github.com/juju/errors"
 )
 
 // Repo allows to operate a chart repository.
@@ -59,76 +49,6 @@ func (r *Repo) GetUploadURL() string {
 	u := *r.url
 	u.Path += "/api/charts"
 	return u.String()
-}
-
-// Upload uploads a chart to the repo.
-func (r *Repo) Upload(file string, _ *chart.Metadata) error {
-	f, err := os.Open(file)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer f.Close()
-
-	body := &bytes.Buffer{}
-	mpw := multipart.NewWriter(body)
-	cw, err := mpw.CreateFormFile("chart", file)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Invalidate cache to avoid inconsistency between an old cache result and
-	// the chart repo
-	if err = r.cache.Invalidate(filepath.Base(file)); err != nil {
-		return errors.Trace(err)
-	}
-
-	// Write file to the multipart and cache writers at the same time.
-	cachew, err := r.cache.Writer(filepath.Base(file))
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer cachew.Close()
-
-	w := io.MultiWriter(cw, cachew)
-	_, err = io.Copy(w, f)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	contentType := mpw.FormDataContentType()
-	if err = mpw.Close(); err != nil {
-		return errors.Trace(err)
-	}
-
-	u := r.GetUploadURL()
-	req, err := http.NewRequest("POST", u, body)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	req.Header.Add("content-type", contentType)
-	if r.username != "" && r.password != "" {
-		req.SetBasicAuth(r.username, r.password)
-	}
-
-	reqID := utils.EncodeSha1(u + file)
-	klog.V(4).Infof("[%s] POST %q", reqID, u)
-	client := utils.DefaultClient
-	if r.insecure {
-		client = utils.InsecureClient
-	}
-	res, err := client.Do(req)
-	if err != nil {
-		return errors.Annotatef(err, "uploading %q chart", file)
-	}
-	defer res.Body.Close()
-
-	bodyStr := utils.HTTPResponseBody(res)
-	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
-		return errors.Errorf("unable to upload %q chart, got HTTP Status: %s, Resp: %v", file, res.Status, bodyStr)
-	}
-	klog.V(4).Infof("[%s] HTTP Status: %s, Resp: %v", reqID, res.Status, bodyStr)
-
-	return nil
 }
 
 // Fetch downloads a chart from the repo

--- a/pkg/client/repo/chartmuseum/chartmuseum_test.go
+++ b/pkg/client/repo/chartmuseum/chartmuseum_test.go
@@ -1,9 +1,7 @@
 package chartmuseum_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -17,7 +15,6 @@ import (
 	"github.com/bitnami/charts-syncer/internal/cache/cachedisk"
 	"github.com/bitnami/charts-syncer/internal/utils"
 	"github.com/bitnami/charts-syncer/pkg/client/repo/chartmuseum"
-	"github.com/bitnami/charts-syncer/pkg/client/repo/helmclassic"
 	"github.com/bitnami/charts-syncer/pkg/client/types"
 )
 
@@ -167,43 +164,5 @@ func TestGetUploadURL(t *testing.T) {
 	got := c.GetUploadURL()
 	if got != want {
 		t.Errorf("wrong upload URL. got: %v, want: %v", got, want)
-	}
-}
-
-func TestUpload(t *testing.T) {
-	c, err := prepareTest(t)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.Upload("../../../../testdata/apache-7.3.15.tgz", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Check the chart really was added to the service's index.
-	req, err := http.NewRequest("GET", cmRepo.Url+"/api/charts/apache", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(cmRepo.Auth.Username, cmRepo.Auth.Password)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	charts := []*helmclassic.ChartVersion{}
-	if err := json.NewDecoder(resp.Body).Decode(&charts); err != nil {
-		t.Fatal(err)
-	}
-	if got, want := len(charts), 1; got != want {
-		t.Fatalf("got: %q, want: %q", got, want)
-	}
-	if got, want := charts[0].Name, "apache"; got != want {
-		t.Errorf("got: %q, want: %q", got, want)
-	}
-	if got, want := charts[0].Version, "7.3.15"; got != want {
-		t.Errorf("got: %q, want: %q", got, want)
 	}
 }

--- a/pkg/client/repo/harbor/harbor.go
+++ b/pkg/client/repo/harbor/harbor.go
@@ -2,23 +2,14 @@
 package harbor
 
 import (
-	"bytes"
-	"io"
-	"mime/multipart"
-	"net/http"
 	"net/url"
-	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/bitnami/charts-syncer/api"
 	"github.com/bitnami/charts-syncer/internal/cache"
-	"github.com/bitnami/charts-syncer/internal/utils"
 	"github.com/bitnami/charts-syncer/pkg/client/repo/helmclassic"
 	"github.com/bitnami/charts-syncer/pkg/client/types"
 	"github.com/juju/errors"
-	"helm.sh/helm/v3/pkg/chart"
-	"k8s.io/klog"
 )
 
 // Repo allows to operate a chart repository.
@@ -58,75 +49,6 @@ func (r *Repo) GetUploadURL() string {
 	u := *r.url
 	u.Path = strings.Replace(u.Path, "/chartrepo/", "/api/chartrepo/", 1) + "/charts"
 	return u.String()
-}
-
-// Upload uploads a chart to the repo
-func (r *Repo) Upload(file string, _ *chart.Metadata) error {
-	f, err := os.Open(file)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer f.Close()
-
-	body := &bytes.Buffer{}
-	mpw := multipart.NewWriter(body)
-	cw, err := mpw.CreateFormFile("chart", file)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Invalidate cache to avoid inconsistency between an old cache result and
-	// the chart repo
-	if err = r.cache.Invalidate(filepath.Base(file)); err != nil {
-		return errors.Trace(err)
-	}
-
-	// Write file to the multipart and cache writers at the same time.
-	cachew, err := r.cache.Writer(filepath.Base(file))
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer cachew.Close()
-
-	w := io.MultiWriter(cw, cachew)
-	_, err = io.Copy(w, f)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	contentType := mpw.FormDataContentType()
-	if err = mpw.Close(); err != nil {
-		return errors.Trace(err)
-	}
-
-	u := r.GetUploadURL()
-	req, err := http.NewRequest("POST", u, body)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	req.Header.Add("content-type", contentType)
-	if r.username != "" && r.password != "" {
-		req.SetBasicAuth(r.username, r.password)
-	}
-
-	reqID := utils.EncodeSha1(u + file)
-	klog.V(4).Infof("[%s] POST %q", reqID, u)
-	client := utils.DefaultClient
-	if r.insecure {
-		client = utils.InsecureClient
-	}
-	res, err := client.Do(req)
-	if err != nil {
-		return errors.Annotatef(err, "uploading %q chart", file)
-	}
-	defer res.Body.Close()
-	if ok := res.StatusCode >= 200 && res.StatusCode <= 299; !ok {
-		bodyStr := utils.HTTPResponseBody(res)
-		return errors.Errorf("unable to fetch index.yaml, got HTTP Status: %s, Resp: %v", res.Status, bodyStr)
-	}
-	klog.V(4).Infof("[%s] HTTP Status: %s", reqID, res.Status)
-
-	return nil
 }
 
 // Fetch downloads a chart from the repo

--- a/pkg/client/repo/harbor/harbor_test.go
+++ b/pkg/client/repo/harbor/harbor_test.go
@@ -1,9 +1,7 @@
 package harbor_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -18,7 +16,6 @@ import (
 	"github.com/bitnami/charts-syncer/internal/cache/cachedisk"
 	"github.com/bitnami/charts-syncer/internal/utils"
 	"github.com/bitnami/charts-syncer/pkg/client/repo/harbor"
-	"github.com/bitnami/charts-syncer/pkg/client/repo/helmclassic"
 	"github.com/bitnami/charts-syncer/pkg/client/types"
 )
 
@@ -175,43 +172,5 @@ func TestGetUploadURL(t *testing.T) {
 	got := c.GetUploadURL()
 	if got != want {
 		t.Errorf("wrong upload URL. got: %v, want: %v", got, want)
-	}
-}
-
-func TestUpload(t *testing.T) {
-	c, err := prepareTest(t)
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = c.Upload("../../../../testdata/apache-7.3.15.tgz", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Check the chart really was added to the service's index.
-	req, err := http.NewRequest("GET", harborRepo.Url+"/apache", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.SetBasicAuth(harborRepo.Auth.Username, harborRepo.Auth.Password)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer resp.Body.Close()
-
-	charts := []*helmclassic.ChartVersion{}
-	if err := json.NewDecoder(resp.Body).Decode(&charts); err != nil {
-		t.Fatal(err)
-	}
-	if got, want := len(charts), 1; got != want {
-		t.Fatalf("got: %q, want: %q", got, want)
-	}
-	if got, want := charts[0].Name, "apache"; got != want {
-		t.Errorf("got: %q, want: %q", got, want)
-	}
-	if got, want := charts[0].Version, "7.3.15"; got != want {
-		t.Errorf("got: %q, want: %q", got, want)
 	}
 }

--- a/pkg/client/repo/helmclassic/helmclassic.go
+++ b/pkg/client/repo/helmclassic/helmclassic.go
@@ -8,7 +8,6 @@ import (
 	"os"
 
 	"github.com/juju/errors"
-	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/repo"
 	"k8s.io/klog"
 
@@ -185,11 +184,6 @@ func (r *Repo) Has(name string, version string) (bool, error) {
 // GetUploadURL returns the URL to upload a chart
 func (r *Repo) GetUploadURL() string {
 	return ""
-}
-
-// Upload uploads a chart to the repo
-func (r *Repo) Upload(_ string, _ *chart.Metadata) error {
-	return errors.Errorf("upload method is not supported yet")
 }
 
 // GetChartDetails returns the details of a chart

--- a/pkg/client/repo/helmclassic/helmclassic_test.go
+++ b/pkg/client/repo/helmclassic/helmclassic_test.go
@@ -197,12 +197,3 @@ func TestGetIndexURL(t *testing.T) {
 		t.Errorf("wrong index URL. got: %v, want: %v", got, want)
 	}
 }
-
-func TestUpload(t *testing.T) {
-	c := prepareTest(t, "index.yaml")
-	expectedError := "upload method is not supported yet"
-	err := c.Upload("../../../testdata/apache-7.3.15.tgz", nil)
-	if err.Error() != expectedError {
-		t.Errorf("unexpected error message. got: %q, want: %q", err.Error(), expectedError)
-	}
-}

--- a/pkg/client/repo/local/local.go
+++ b/pkg/client/repo/local/local.go
@@ -10,10 +10,10 @@ import (
 	"sort"
 
 	"github.com/juju/errors"
+	"helm.sh/helm/v3/pkg/chart"
 
 	"github.com/bitnami/charts-syncer/internal/utils"
 	"github.com/bitnami/charts-syncer/pkg/client/types"
-	"helm.sh/helm/v3/pkg/chart"
 )
 
 var (

--- a/pkg/client/repo/local/local_test.go
+++ b/pkg/client/repo/local/local_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/bitnami/charts-syncer/pkg/client/repo/local"
 	"github.com/bitnami/charts-syncer/pkg/client/types"
-	"helm.sh/helm/v3/pkg/chart"
 	"helm.sh/helm/v3/pkg/time"
 )
 
@@ -92,27 +91,5 @@ func TestGetChartDetails(t *testing.T) {
 	}
 	if want.Digest != got.Digest {
 		t.Errorf("unexpected digest in chart. got: %v, want: %v", got, want)
-	}
-}
-
-func TestUpload(t *testing.T) {
-	c, err := local.New("../../../../testdata/wraps")
-	if err != nil {
-		t.Fatal(err)
-	}
-	cMetadata := chart.Metadata{
-		Name:    "apache",
-		Version: "7.3.15",
-	}
-	err = c.Upload("../../../../testdata/apache-7.3.15.tgz", &cMetadata)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expectedChartPath := "../../../../testdata/wraps/apache-7.3.15.wrap.tgz"
-	if _, err := os.Stat(expectedChartPath); err != nil {
-		t.Errorf("chart package does not exist after upload method")
-	}
-	if err := os.Remove(expectedChartPath); err != nil {
-		t.Errorf("error cleaning chart path from %q after successful upload", expectedChartPath)
 	}
 }

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -9,12 +9,15 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/bitnami/charts-syncer/api"
+	"github.com/bitnami/charts-syncer/internal/cache"
+	"github.com/bitnami/charts-syncer/internal/indexer"
+	"github.com/bitnami/charts-syncer/internal/utils"
+	"github.com/bitnami/charts-syncer/pkg/client/types"
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/google/go-containerregistry/pkg/authn"
@@ -23,18 +26,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/juju/errors"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
-	orascontext "oras.land/oras-go/pkg/context"
-
-	"helm.sh/helm/v3/pkg/chart"
 	"k8s.io/klog"
-	"oras.land/oras-go/pkg/content"
-	"oras.land/oras-go/pkg/oras"
-
-	"github.com/bitnami/charts-syncer/api"
-	"github.com/bitnami/charts-syncer/internal/cache"
-	"github.com/bitnami/charts-syncer/internal/indexer"
-	"github.com/bitnami/charts-syncer/internal/utils"
-	"github.com/bitnami/charts-syncer/pkg/client/types"
 )
 
 const (
@@ -329,72 +321,6 @@ func (r *Repo) Has(chartName string, version string) (bool, error) {
 // GetUploadURL returns the upload URL
 func (r *Repo) GetUploadURL() string {
 	return fmt.Sprintf("%s%s", r.url.Host, r.url.Path)
-}
-
-// Upload uploads a chart to the repo
-func (r *Repo) Upload(file string, metadata *chart.Metadata) error {
-	name := metadata.Name
-	version := metadata.Version
-	// Invalidate cache to avoid inconsistency between an old cache result and
-	// the chart repo
-	if err := r.cache.Invalidate(filepath.Base(file)); err != nil {
-		return errors.Trace(err)
-	}
-
-	f, err := os.Open(file)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	defer f.Close()
-
-	if err = r.cache.Store(f, filepath.Base(file)); err != nil {
-		return errors.Trace(err)
-	}
-
-	memoryStore := content.NewMemory()
-	resolver := r.dockerResolver
-
-	// Preparing layers
-	fileName := filepath.Base(file)
-	fileMediaType := HelmChartContentLayerMediaType
-	fileBuffer, err := os.ReadFile(file)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	blobDesc, err := memoryStore.Add(fileName, fileMediaType, fileBuffer)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	// Preparing Oras config
-	configBytes, err := json.Marshal(metadata)
-	if err != nil {
-		return err
-	}
-	configDesc, err := memoryStore.Add("", HelmChartConfigMediaType, configBytes)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	manifest, manifestDesc, err := content.GenerateManifest(&configDesc, nil, blobDesc)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	// helm replaces plus(+) characters with underscores(_) in the tag (version)
-	chartRef := fmt.Sprintf("%s%s/%s:%s", r.url.Host, r.url.Path, name, strings.ReplaceAll(version, "+", "_"))
-	if err := memoryStore.StoreManifest(chartRef, manifestDesc, manifest); err != nil {
-		return errors.Trace(err)
-	}
-
-	// Perform push
-	copyOpts := []oras.CopyOpt{
-		oras.WithAllowedMediaType(HelmChartConfigMediaType, HelmChartContentLayerMediaType),
-		oras.WithNameValidation(nil),
-	}
-	if _, err := oras.Copy(orascontext.Background(), memoryStore, chartRef, resolver, chartRef, copyOpts...); err != nil {
-		return errors.Trace(err)
-	}
-	return nil
 }
 
 // GetChartDetails returns the details of a chart

--- a/pkg/client/repo/oci/oci_test.go
+++ b/pkg/client/repo/oci/oci_test.go
@@ -45,7 +45,7 @@ func TestFetch(t *testing.T) {
 	}
 	// helm replaces plus(+) characters with underscores(_) in the tag (version)
 	chartRef := fmt.Sprintf("%s%s/%s:%s", u.Host, u.Path, chartMetadata.Name, strings.ReplaceAll(chartMetadata.Version, "+", "_"))
-	if err := oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
+	if err = oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
 		t.Fatal(err)
 	}
 
@@ -82,7 +82,7 @@ func TestHas(t *testing.T) {
 	}
 	// helm replaces plus(+) characters with underscores(_) in the tag (version)
 	chartRef := fmt.Sprintf("%s%s/%s:%s", u.Host, u.Path, chartMetadata.Name, strings.ReplaceAll(chartMetadata.Version, "+", "_"))
-	if err := oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
+	if err = oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
 		t.Fatal(err)
 	}
 
@@ -129,7 +129,7 @@ func TestListChartVersions(t *testing.T) {
 	}
 	// helm replaces plus(+) characters with underscores(_) in the tag (version)
 	chartRef := fmt.Sprintf("%s%s/%s:%s", u.Host, u.Path, chartMetadata.Name, strings.ReplaceAll(chartMetadata.Version, "+", "_"))
-	if err := oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
+	if err = oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/client/repo/oci/oci_test.go
+++ b/pkg/client/repo/oci/oci_test.go
@@ -130,35 +130,3 @@ func TestReload(t *testing.T) {
 		t.Errorf("unexpected error message. got: %q, want: %q", err.Error(), expectedError)
 	}
 }
-
-func TestUpload(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	oci.PrepareOCIServer(ctx, t, ociRepo)
-	c := oci.PrepareTest(t, ociRepo)
-	chartMetadata := &chart.Metadata{
-		Name:    "apache",
-		Version: "7.3.15",
-	}
-	if err := c.Upload("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata); err != nil {
-		t.Fatal(err)
-	}
-
-	chartPath, err := c.Fetch("apache", "7.3.15")
-	if err != nil {
-		t.Fatalf("error fetching chart: %v", err)
-	}
-
-	if _, err = os.Stat(chartPath); err != nil {
-		t.Errorf("chart package does not exist")
-	}
-
-	contentType, err := utils.GetFileContentType(chartPath)
-	if err != nil {
-		t.Fatalf("error checking contentType of %s file", chartPath)
-	}
-
-	if contentType != "application/x-gzip" {
-		t.Errorf("incorrect content type, got: %s, want: %s.", contentType, "application/x-gzip")
-	}
-}

--- a/pkg/client/repo/oci/oci_test.go
+++ b/pkg/client/repo/oci/oci_test.go
@@ -2,9 +2,12 @@ package oci_test
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"os"
 	"reflect"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/bitnami/charts-syncer/api"
@@ -36,7 +39,13 @@ func TestFetch(t *testing.T) {
 		Version: "7.3.15",
 	}
 
-	if err := c.Upload("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata); err != nil {
+	u, err := url.Parse(ociRepo.Url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// helm replaces plus(+) characters with underscores(_) in the tag (version)
+	chartRef := fmt.Sprintf("%s%s/%s:%s", u.Host, u.Path, chartMetadata.Name, strings.ReplaceAll(chartMetadata.Version, "+", "_"))
+	if err := oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
 		t.Fatal(err)
 	}
 
@@ -66,7 +75,14 @@ func TestHas(t *testing.T) {
 		Name:    "apache",
 		Version: "7.3.15",
 	}
-	if err := c.Upload("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata); err != nil {
+
+	u, err := url.Parse(ociRepo.Url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// helm replaces plus(+) characters with underscores(_) in the tag (version)
+	chartRef := fmt.Sprintf("%s%s/%s:%s", u.Host, u.Path, chartMetadata.Name, strings.ReplaceAll(chartMetadata.Version, "+", "_"))
+	if err := oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
 		t.Fatal(err)
 	}
 
@@ -106,7 +122,14 @@ func TestListChartVersions(t *testing.T) {
 		Name:    "apache",
 		Version: "7.3.15",
 	}
-	if err := c.Upload("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata); err != nil {
+
+	u, err := url.Parse(ociRepo.Url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// helm replaces plus(+) characters with underscores(_) in the tag (version)
+	chartRef := fmt.Sprintf("%s%s/%s:%s", u.Host, u.Path, chartMetadata.Name, strings.ReplaceAll(chartMetadata.Version, "+", "_"))
+	if err := oci.PushChartToOCI("../../../../testdata/apache-7.3.15.wrap.tgz", chartMetadata, chartRef); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/client/repo/oci/ocitester.go
+++ b/pkg/client/repo/oci/ocitester.go
@@ -2,6 +2,7 @@ package oci
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net"
 	"net/http"
@@ -19,7 +20,10 @@ import (
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/distribution/distribution/v3/configuration"
 	"github.com/distribution/distribution/v3/registry"
+	"github.com/juju/errors"
+	"helm.sh/helm/v3/pkg/chart"
 	"oras.land/oras-go/pkg/content"
+	orascontext "oras.land/oras-go/pkg/context"
 	"oras.land/oras-go/pkg/oras"
 
 	"github.com/bitnami/charts-syncer/api"
@@ -48,7 +52,7 @@ type RepoTester struct {
 	index map[string][]*helmclassic.ChartVersion
 }
 
-// PushFileToOCI pushes a file to a OCI repository
+// PushFileToOCI pushes a file to an OCI repository
 func PushFileToOCI(t *testing.T, filepath string, ref string) {
 	ctx := context.Background()
 	resolver := docker.NewResolver(docker.ResolverOptions{PlainHTTP: true})
@@ -76,6 +80,58 @@ func PushFileToOCI(t *testing.T, filepath string, ref string) {
 	if _, err := oras.Copy(ctx, memoryStore, ref, resolver, ref, oras.WithNameValidation(nil)); err != nil {
 		t.Fatal(err)
 	}
+}
+
+// PushChartToOCI pushes a file to an OCI repository
+func PushChartToOCI(file string, metadata *chart.Metadata, ref string) error {
+	f, err := os.Open(file)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	defer f.Close()
+
+	memoryStore := content.NewMemory()
+	resolver := docker.NewResolver(docker.ResolverOptions{PlainHTTP: true})
+
+	// Preparing layers
+	fileName := filepath.Base(file)
+	fileMediaType := HelmChartContentLayerMediaType
+	fileBuffer, err := os.ReadFile(file)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	blobDesc, err := memoryStore.Add(fileName, fileMediaType, fileBuffer)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	// Preparing Oras config
+	configBytes, err := json.Marshal(metadata)
+	if err != nil {
+		return err
+	}
+	configDesc, err := memoryStore.Add("", HelmChartConfigMediaType, configBytes)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	manifest, manifestDesc, err := content.GenerateManifest(&configDesc, nil, blobDesc)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if err := memoryStore.StoreManifest(ref, manifestDesc, manifest); err != nil {
+		return errors.Trace(err)
+	}
+
+	// Perform push
+	copyOpts := []oras.CopyOpt{
+		oras.WithAllowedMediaType(HelmChartConfigMediaType, HelmChartContentLayerMediaType),
+		oras.WithNameValidation(nil),
+	}
+	if _, err := oras.Copy(orascontext.Background(), memoryStore, ref, resolver, ref, copyOpts...); err != nil {
+		return errors.Trace(err)
+	}
+	return nil
 }
 
 // PrepareTest creates a client to interact with OCI servers


### PR DESCRIPTION
### Description of the change

This PR removes some unused methods from the main interfaces. In particular, the Upload() method is unused since we started using the helm-distribution-for-helm library 