### PR TITLE
fix: respect original chart versioning when --latest-version-only flag is set

### DIFF
--- a/pkg/syncer/index.go
+++ b/pkg/syncer/index.go
@@ -4,6 +4,7 @@ import (
 	goerrors "errors"
 	"fmt"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -115,6 +116,10 @@ func (s *Syncer) loadCharts(charts ...string) error {
 			sort.Sort(semver.Collection(vs))
 			// The last element of the array is the latest version
 			version := vs[len(vs)-1].String()
+			// Check if the original version had a prefix
+			if strings.HasPrefix(versions[0], "v") {
+				version = fmt.Sprintf("v%s", version)
+			}
 			if err := s.processVersion(name, version, publishingThreshold); err != nil {
 				klog.Warningf("Failed processing %s:%s chart. The index will remain incomplete.", name, version)
 				errs = goerrors.Join(errs, errors.Trace(err))


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change made charts-syncer to respect the optional `v` prefix in some charts when checking if is already present in the target registry.

### Benefits

Executions with the `--latest-version-only` flag, we will skip the sync if the chart is already in the target registry. Nowadays, due to the bug, we think it is not synced yet and run the command.

### Possible drawbacks

None

### Applicable issues

  - fixes #284

