### PR TITLE
fix: use-plain-http not working on some envs

### DIFF
--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -102,8 +102,7 @@ func (r *Repo) getTagManifest(chartName, version string) (*ocispec.Manifest, err
 	u := *r.url
 	u.Path = path.Join(u.Path, "/", chartName)
 
-	// helm replaces plus(+) characters with underscores(_) in the tag (version)
-	ref, err := name.ParseReference(u.Host + u.Path + ":" + strings.ReplaceAll(version, "+", "_"))
+	ref, err := r.parseReference(u, version)
 	if err != nil {
 		return nil, errors.Errorf("failed parsing OCI reference: %s", err)
 	}
@@ -213,8 +212,7 @@ func (r *Repo) Fetch(chartName string, version string) (string, error) {
 	u := *r.url
 	u.Path = path.Join(u.Path, "/", chartName)
 
-	// helm replaces plus(+) characters with underscores(_) in the tag (version)
-	ref, err := name.ParseReference(u.Host + u.Path + ":" + strings.ReplaceAll(version, "+", "_"))
+	ref, err := r.parseReference(u, version)
 	if err != nil {
 		return "", errors.Errorf("failed parsing OCI reference: %s", err)
 	}
@@ -285,9 +283,7 @@ func (r *Repo) Has(chartName string, version string) (bool, error) {
 	u := *r.url
 	u.Path = path.Join(u.Path, "/", chartName)
 
-	// helm replaces plus(+) characters with underscores(_) in the tag (version)
-	ref, err := name.ParseReference(u.Host + u.Path + ":" + strings.ReplaceAll(version, "+", "_"))
-
+	ref, err := r.parseReference(u, version)
 	if err != nil {
 		return false, errors.Errorf("failed parsing OCI reference: %s", err)
 	}
@@ -353,24 +349,13 @@ func isHelmChartContentLayerMediaType(t string) bool {
 	return false
 }
 
-// ociReferenceExists checks if a given oci reference exists in the repository
-func ociReferenceExists(ociRef, username, password string) (bool, error) {
-	ociReference, err := name.ParseReference(ociRef)
-	if err != nil {
-		return false, errors.Trace(err)
+func (r *Repo) parseReference(u url.URL, version string) (name.Reference, error) {
+	// helm replaces plus(+) characters with underscores(_) in the tag (version)
+	ref := u.Host + u.Path + ":" + strings.ReplaceAll(version, "+", "_")
+	if r.usePlainHTTP {
+		return name.ParseReference(ref, name.Insecure)
 	}
-	authOptions := authn.Basic{Username: username, Password: password}
-	opt := []remote.Option{
-		remote.WithAuth(&authOptions),
-	}
-	_, err = remote.Head(ociReference, opt...)
-	if err != nil {
-		if strings.Contains(err.Error(), "404 Not Found") {
-			return false, nil
-		}
-		return false, errors.Trace(err)
-	}
-	return true, nil
+	return name.ParseReference(ref)
 }
 
 // populateEntries populates the entries map with the info from the charts index

--- a/pkg/client/repo/oci/oci_internal_test.go
+++ b/pkg/client/repo/oci/oci_internal_test.go
@@ -1,70 +1,12 @@
 package oci
 
 import (
-	"context"
-	"fmt"
-	"net/url"
 	"reflect"
 	"sort"
 	"testing"
 
-	apiv1 "github.com/bitnami/charts-syncer/gen/proto/v1"
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 )
-
-var (
-	ociRepo = &apiv1.Repo{
-		Kind: apiv1.Kind_OCI,
-		Auth: &apiv1.Auth{
-			Username: "user",
-			Password: "password",
-		},
-	}
-)
-
-func TestOciReferenceExists(t *testing.T) {
-	tests := []struct {
-		desc          string
-		ociPartialRef string // to be added to repo url returned by PrepareOCIServer
-		pushTestAsset bool
-		want          bool
-	}{
-		{
-			desc:          "Artifact should exist",
-			ociPartialRef: "index:latest",
-			pushTestAsset: true,
-			want:          true,
-		},
-		{
-			desc:          "Artifact should not exist",
-			ociPartialRef: "non-existing-index:latest",
-			pushTestAsset: false,
-			want:          false,
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.desc, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			PrepareOCIServer(ctx, t, ociRepo)
-			u, err := url.Parse(ociRepo.Url)
-			if err != nil {
-				t.Fatal(err)
-			}
-			ociRef := fmt.Sprintf("%s%s/%s", u.Host, u.Path, tc.ociPartialRef)
-			if tc.pushTestAsset {
-				PushFileToOCI(t, "../../../../testdata/oci/index.json", ociRef)
-			}
-			got, err := ociReferenceExists(ociRef, ociRepo.GetAuth().GetUsername(), ociRepo.GetAuth().GetPassword())
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != tc.want {
-				t.Errorf("wrong result from OCI reference existence check. got: %v, want: %v", got, tc.want)
-			}
-		})
-	}
-}
 
 func TestListWithEntries(t *testing.T) {
 	entries := map[string][]string{


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This PR will make the go-containerregistry library to properly parse the OCI reference when the flag --use-plain-http is set

### Benefits

The --use-plain-http flag will work fine in more environments

### Possible drawbacks
 
None

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
  - fixes #292
