### PR TITLE
fix: extend tag regex to cover more image tag valid formats

### DIFF
--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -270,10 +270,13 @@ func (r *Repo) ListContainerTags(containerName string) ([]string, error) {
 	return containerTags, nil
 }
 
-// tagRegex matches container image tags following the scheme MAJOR.MINOR.PATCH-DISTRO_NAME-DISTRO_VERSION-rREVISION
-// (e.g. "13.16.0-photon-5-r19", "7.4.1-debian-12-r6", "1.27.3-ubuntu-22-r0").
-// Tags that do not follow this pattern (latest, stable, sha256:...) are excluded.
-var tagRegex = regexp.MustCompile(`^\d+\.\d+\.\d+-[a-z]+-\d+-r\d+$`)
+// tagRegex matches container image tags in the following schemes:
+//   - MAJOR.MINOR.PATCH-DISTRO-DISTRO_VER-rREV        (e.g. "13.16.0-photon-5-r19", "7.4.1-debian-12-r6")
+//   - MAJOR.MINOR.PATCH-BUILD-DISTRO-DISTRO_VER-rREV  (e.g. "17.0.16-12-photon-5-r0")
+//   - MAJOR-DISTRO-DISTRO_VER-rREV                    (e.g. "5-photon-5-r19")
+//
+// Tags that do not follow these patterns (latest, stable, sha256:...) are excluded.
+var tagRegex = regexp.MustCompile(`^(\d+\.\d+\.\d+(-\d+)?|\d+)-[a-z]+-\d+-r\d+$`)
 
 func looksLikeDockerImageTag(tag string) bool {
 	return tagRegex.MatchString(tag)

--- a/pkg/client/repo/oci/oci_internal_test.go
+++ b/pkg/client/repo/oci/oci_internal_test.go
@@ -8,6 +8,41 @@ import (
 	_ "github.com/distribution/distribution/v3/registry/storage/driver/inmemory"
 )
 
+func TestLooksLikeDockerImageTag(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		// Standard MAJOR.MINOR.PATCH-DISTRO-DVER-rREV
+		{"13.16.0-photon-5-r19", true},
+		{"7.4.1-debian-12-r6", true},
+		{"1.27.3-ubuntu-22-r0", true},
+		// MAJOR.MINOR.PATCH-BUILD-DISTRO-DVER-rREV (extra build/epoch segment)
+		{"17.0.16-12-photon-5-r0", true},
+		{"11.2.3-45-debian-12-r1", true},
+		// MAJOR-DISTRO-DVER-rREV (single integer version)
+		{"5-photon-5-r19", true},
+		{"3-debian-12-r0", true},
+		// Non-matching tags
+		{"latest", false},
+		{"stable", false},
+		{"sha256:abc123", false},
+		{"1.0.0", false},
+		{"1.0.0-r1", false},
+		{"1.0.0-debian", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.tag, func(t *testing.T) {
+			got := looksLikeDockerImageTag(tt.tag)
+			if got != tt.want {
+				t.Errorf("looksLikeDockerImageTag(%q) = %v, want %v", tt.tag, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestListWithEntries(t *testing.T) {
 	entries := map[string][]string{
 		"chartA": {"1.0.1", "1.0.2"},


### PR DESCRIPTION
## Problem

`ListContainerTags` was silently dropping tags for images like `java-min` and `os-shell` because their tag formats did not match the hardcoded `tagRegex`. As a result, `DiffPendingContainers` would always return an empty list and report "There are no containers out of sync!" even when those images had never been synced to the target registry.

The two unmatched formats were:
- `17.0.16-12-photon-5-r0` — a `MAJOR.MINOR.PATCH-BUILD-DISTRO-DISTRO_VER-rREV` scheme with an extra build/epoch number between the patch version and the distro name.
- `5-photon-5-r19` — a bare single-integer version scheme (`MAJOR-DISTRO-DISTRO_VER-rREV`) used by tools like `os-shell`.

## Fix

Updated `tagRegex` in `pkg/client/repo/oci/oci.go` to cover all three known Bitnami tag formats using an alternation in the version prefix:

```
^(\d+.\d+.\d+(-\d+)?|\d+)-[a-z]+-\d+-r\d+$
```

- `\d+\.\d+\.\d+` — standard three-part semver (unchanged)
- `(-\d+)?` — optional extra build/epoch segment
- `|\d+` — OR a bare single integer

## Testing

Added a table-driven unit test `TestLooksLikeDockerImageTag` in `pkg/client/repo/oci/oci_internal_test.go` covering all three valid formats and several invalid ones (`latest`, `stable`, `sha256:...`, etc.).