### PR TITLE
feat: don't preserve extra container repository path from origin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
-	github.com/vmware-labs/distribution-tooling-for-helm v0.6.1
+	github.com/vmware-labs/distribution-tooling-for-helm v0.7.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.19.0

--- a/go.sum
+++ b/go.sum
@@ -689,8 +689,8 @@ github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
-github.com/vmware-labs/distribution-tooling-for-helm v0.6.1 h1:dlhWvDevr3P86B7BipkREhMOtSZS9WxNoAwLtRUSewY=
-github.com/vmware-labs/distribution-tooling-for-helm v0.6.1/go.mod h1:Q6WupfRDDMi6qBcta2IK6UUAt14xe64ug8kLRfiuImY=
+github.com/vmware-labs/distribution-tooling-for-helm v0.7.0 h1:FJXG066yrovW8U/mEgQbhtQZe11DS0zpIot+GGVQzGA=
+github.com/vmware-labs/distribution-tooling-for-helm v0.7.0/go.mod h1:Q6WupfRDDMi6qBcta2IK6UUAt14xe64ug8kLRfiuImY=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/vmware-tanzu/carvel-imgpkg v0.38.3 h1:vVnqCPFEZ2NQcoTywg/va91qRyCuu46wBYAETqoyez4=

--- a/pkg/client/target/common/common.go
+++ b/pkg/client/target/common/common.go
@@ -68,7 +68,9 @@ func NewContainer(target *apiv1.Target, containersReaderWriter client.Containers
 func (t *Target) getContainersUploadURL() string {
 	containersURL := t.containersURL
 	if containersURL == "" {
-		containersURL = t.GetUploadURL()
+		// When containers URL is not specified, append /containers to charts URL
+		// to avoid collision between charts and containers at the same path
+		containersURL = t.GetUploadURL() + "/containers"
 	}
 
 	if schemeRE.MatchString(containersURL) {
@@ -97,6 +99,7 @@ func (t *Target) UnwrapChart(file string, _ *chart.Metadata, opts ...config.Opti
 		unwrap.WithContainerRegistryAuth(t.containersUsername, t.containersPassword),
 		unwrap.WithSkipImageRelocation(cfg.SkipImages),
 		unwrap.WithSkipPullImages(cfg.SkipImages),
+		unwrap.WithPreserveRepository(false),
 	); err != nil {
 		return errors.Trace(err)
 	}
@@ -124,6 +127,7 @@ func (t *Target) UnwrapContainer(file string, opts ...config.Option) error {
 		unwrap.WithSkipImageRelocation(cfg.SkipImages),
 		unwrap.WithSkipPullImages(cfg.SkipImages),
 		unwrap.WithFetchArtifacts(!cfg.SkipArtifacts),
+		unwrap.WithPreserveRepository(false),
 	); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/client/target/common/common_test.go
+++ b/pkg/client/target/common/common_test.go
@@ -12,7 +12,7 @@ type MockChartsReaderWriter struct {
 	uploadURL string
 }
 
-func (m *MockChartsReaderWriter) Fetch(name, version string) (string, error) {
+func (m *MockChartsReaderWriter) Fetch(_, _ string) (string, error) {
 	return "", nil
 }
 
@@ -20,15 +20,15 @@ func (m *MockChartsReaderWriter) List() ([]string, error) {
 	return []string{}, nil
 }
 
-func (m *MockChartsReaderWriter) ListChartVersions(name string) ([]string, error) {
+func (m *MockChartsReaderWriter) ListChartVersions(_ string) ([]string, error) {
 	return []string{}, nil
 }
 
-func (m *MockChartsReaderWriter) Has(name, version string) (bool, error) {
+func (m *MockChartsReaderWriter) Has(_, _ string) (bool, error) {
 	return false, nil
 }
 
-func (m *MockChartsReaderWriter) GetChartDetails(name, version string) (*types.ChartDetails, error) {
+func (m *MockChartsReaderWriter) GetChartDetails(_, _ string) (*types.ChartDetails, error) {
 	return nil, nil
 }
 

--- a/pkg/client/target/common/common_test.go
+++ b/pkg/client/target/common/common_test.go
@@ -1,0 +1,122 @@
+package common
+
+import (
+	"testing"
+
+	apiv1 "github.com/bitnami/charts-syncer/gen/proto/v1"
+	"github.com/bitnami/charts-syncer/pkg/client/types"
+)
+
+// MockChartsReaderWriter is a mock implementation of ChartsReaderWriter
+type MockChartsReaderWriter struct {
+	uploadURL string
+}
+
+func (m *MockChartsReaderWriter) Fetch(name, version string) (string, error) {
+	return "", nil
+}
+
+func (m *MockChartsReaderWriter) List() ([]string, error) {
+	return []string{}, nil
+}
+
+func (m *MockChartsReaderWriter) ListChartVersions(name string) ([]string, error) {
+	return []string{}, nil
+}
+
+func (m *MockChartsReaderWriter) Has(name, version string) (bool, error) {
+	return false, nil
+}
+
+func (m *MockChartsReaderWriter) GetChartDetails(name, version string) (*types.ChartDetails, error) {
+	return nil, nil
+}
+
+func (m *MockChartsReaderWriter) GetUploadURL() string {
+	return m.uploadURL
+}
+
+func TestGetContainersUploadURL_WithoutExplicitContainersURL(t *testing.T) {
+	// Test case: target.containers is nil, should append /containers to chart URL
+	target := &apiv1.Target{
+		Repo: &apiv1.Repo{
+			Url: "http://127.0.0.1:5000/library-replicated/charts/photon-5",
+		},
+		Containers: nil,
+	}
+
+	t.Run("containers_url_not_specified", func(t *testing.T) {
+		mockCharts := &MockChartsReaderWriter{
+			uploadURL: "http://127.0.0.1:5000/library-replicated/charts/photon-5",
+		}
+		targetObj, err := New(target, mockCharts, false, false)
+		if err != nil {
+			t.Fatalf("error creating target: %v", err)
+		}
+
+		got := targetObj.getContainersUploadURL()
+		want := "127.0.0.1:5000/library-replicated/charts/photon-5/containers"
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestGetContainersUploadURL_WithExplicitContainersURL(t *testing.T) {
+	// Test case: target.containers is specified, should use that URL
+	target := &apiv1.Target{
+		Repo: &apiv1.Repo{
+			Url: "http://127.0.0.1:5000/library-replicated/charts/photon-5",
+		},
+		Containers: &apiv1.Containers{
+			Url: "http://127.0.0.1:5000/library-replicated/containers/photon-5",
+		},
+	}
+
+	t.Run("containers_url_specified", func(t *testing.T) {
+		mockCharts := &MockChartsReaderWriter{
+			uploadURL: "http://127.0.0.1:5000/library-replicated/charts/photon-5",
+		}
+		targetObj, err := New(target, mockCharts, false, false)
+		if err != nil {
+			t.Fatalf("error creating target: %v", err)
+		}
+
+		got := targetObj.getContainersUploadURL()
+		want := "127.0.0.1:5000/library-replicated/containers/photon-5"
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestGetContainersUploadURL_StripsScheme(t *testing.T) {
+	// Test case: verify that scheme is stripped correctly
+	target := &apiv1.Target{
+		Repo: &apiv1.Repo{
+			Url: "oci://127.0.0.1:5000/library-replicated/charts/photon-5",
+		},
+		Containers: nil,
+	}
+
+	t.Run("scheme_stripped_with_containers_suffix", func(t *testing.T) {
+		mockCharts := &MockChartsReaderWriter{
+			uploadURL: "oci://127.0.0.1:5000/library-replicated/charts/photon-5",
+		}
+		targetObj, err := New(target, mockCharts, false, false)
+		if err != nil {
+			t.Fatalf("error creating target: %v", err)
+		}
+
+		got := targetObj.getContainersUploadURL()
+		// Scheme should be stripped, and /containers should be appended before scheme removal
+		// Actually, the scheme removal happens after appending /containers
+		want := "127.0.0.1:5000/library-replicated/charts/photon-5/containers"
+
+		if got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+}

--- a/test/run-verifications.sh
+++ b/test/run-verifications.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 # Constants
 FAILED_TEST=0
-EXPECTED_REGISTRY='localhost:5000/library/bitnami'
+EXPECTED_REGISTRY='localhost:5000/library/containers'
 
 ## Check that WordPress deployment is using the expected registry
 wordpressImage=$(kubectl get pods --selector=app.kubernetes.io/name=wordpress -ojsonpath='{.items[0].spec.containers[0].image}')


### PR DESCRIPTION
## Summary

This PR upgrades the `distribution-tooling-for-helm` library to version 0.7.0 and implements changes to better handle container repository structure and URL resolution.

## Changes

### Dependency Updates
- **Upgraded `distribution-tooling-for-helm`** from v0.6.1 to v0.7.0 to leverage latest features and fixes

### Container URL Resolution Enhancement  
- **Modified container URL logic**: When no explicit containers URL is specified, the system now appends `/containers` to the charts URL instead of using the same path
- This prevents collisions between charts and containers when they would otherwise be stored at the same location
- **Example**: If charts URL is `http://127.0.0.1:5000/library-replicated/charts/photon-5`, containers will now use `http://127.0.0.1:5000/library-replicated/charts/photon-5/containers`

### Image Repository Handling
- **Added `WithPreserveRepository(false)`** option to both chart and container unwrapping operations
- This ensures consistent behavior in how image repositories are handled during the unwrapping process

### Testing
- **Added comprehensive unit tests** (`common_test.go`) covering:
  - Container URL resolution when no explicit containers URL is provided
  - Container URL resolution when explicit containers URL is specified
  - Proper URL formatting and scheme handling

## Test Plan

- [x] Unit tests pass for container URL resolution logic
- [x] Charts and containers are properly separated when using default URL resolution
- [x] Image repository preservation behavior is consistent across chart and container operations