### PR TITLE
chore: update distribution-tooling-for-helm library version to 0.7.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
-	github.com/vmware-labs/distribution-tooling-for-helm v0.7.0
+	github.com/vmware-labs/distribution-tooling-for-helm v0.7.1
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.20.2

--- a/go.sum
+++ b/go.sum
@@ -679,8 +679,8 @@ github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
-github.com/vmware-labs/distribution-tooling-for-helm v0.7.0 h1:FJXG066yrovW8U/mEgQbhtQZe11DS0zpIot+GGVQzGA=
-github.com/vmware-labs/distribution-tooling-for-helm v0.7.0/go.mod h1:Q6WupfRDDMi6qBcta2IK6UUAt14xe64ug8kLRfiuImY=
+github.com/vmware-labs/distribution-tooling-for-helm v0.7.1 h1:W317lsSnEc+4UOmNGQjHSV7RpcLzOAmEFi4suuq+rlY=
+github.com/vmware-labs/distribution-tooling-for-helm v0.7.1/go.mod h1:Q6WupfRDDMi6qBcta2IK6UUAt14xe64ug8kLRfiuImY=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/vmware-tanzu/carvel-imgpkg v0.38.3 h1:vVnqCPFEZ2NQcoTywg/va91qRyCuu46wBYAETqoyez4=


### PR DESCRIPTION
Update distribution-tooling-for-helm library to version 0.7.1 to benefit from vmware-labs/distribution-tooling-for-helm#146

Fixes https://github.com/bitnami/charts-syncer/issues/342