### PR TITLE
fix: correctly handle --insecure in OCI index downloader

### DIFF
--- a/internal/indexer/resolver.go
+++ b/internal/indexer/resolver.go
@@ -1,6 +1,9 @@
 package indexer
 
 import (
+	"crypto/tls"
+	"net/http"
+
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
@@ -13,12 +16,21 @@ func newRemoteRepository(ref, username, password string, insecure bool, usePlain
 		return nil, err
 	}
 
-	if insecure || usePlainHTTP {
+	if usePlainHTTP {
 		repo.PlainHTTP = true
 	}
 
+	httpClient := retry.DefaultClient
+	if insecure {
+		httpClient = &http.Client{
+			Transport: retry.NewTransport(&http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // #nosec G402
+			}),
+		}
+	}
+
 	repo.Client = &auth.Client{
-		Client: retry.DefaultClient,
+		Client: httpClient,
 		Cache:  auth.NewCache(),
 		Credential: auth.StaticCredential(repo.Reference.Registry, auth.Credential{
 			Username: username,


### PR DESCRIPTION
## Problem

The `--insecure` flag was mishandled in the ORAS-based OCI index downloader. When passed, it set `repo.PlainHTTP = true` on the `remote.Repository`, which silently downgraded the connection to **plain HTTP** — discarding TLS entirely instead of just relaxing certificate validation.

The intended behaviour of `--insecure` is to connect over **HTTPS but skip certificate verification**, which is the correct approach for registries with self-signed or otherwise invalid certificates.

## Fix

`newRemoteRepository` in `internal/indexer/resolver.go` now handles the two flags independently:

- **`--use-plain-http`** → sets `repo.PlainHTTP = true` (no TLS, connects over plain HTTP)
- **`--insecure`** → keeps `PlainHTTP = false` (HTTPS) but wraps the retry transport with `InsecureSkipVerify: true`, matching the behaviour already used by the rest of the OCI client in `pkg/client/repo/oci/oci.go`

```go
// Before (both flags collapsed to the same wrong behaviour)
if insecure || usePlainHTTP {
    repo.PlainHTTP = true
}

// After (flags handled independently)
if usePlainHTTP {
    repo.PlainHTTP = true
}
httpClient := retry.DefaultClient
if insecure {
    httpClient = &http.Client{
        Transport: retry.NewTransport(&http.Transport{
            TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
        }),
    }
}
```

## Migration note

Users who were (accidentally) relying on `--insecure` to connect to a plain-HTTP index server should switch to `--use-plain-http`. The `--insecure` flag will now correctly attempt HTTPS and only skip certificate verification.

## Testing

- [x] `go build ./...` passes with no errors
- [x] `go test ./internal/indexer/...` passes

Made with [Cursor](https://cursor.com)