### PR TITLE
feat: add config option to preserve chart-digest (skip chart modifications)

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,27 @@ charts:
 skipImages: true
 ```
 
+### Preserve the original digest of charts and container images
+
+By default, charts and container images are unpacked and rebuilt as they are relocated to the target repo, which changes their manifest digest. If you need byte-for-byte mirroring instead, so the destination digest (and any signature made against it) matches the source exactly, set `preserveDigest` to true:
+
+```yaml
+source:
+  repo:
+    kind: OCI
+    url: http://localhost:8080
+target:
+  repo:
+    kind: OCI
+    url: http://localhost:9090/charts
+charts:
+  - redis
+
+preserveDigest: true
+```
+
+`preserveDigest` is not compatible with `containerPlatforms`: filtering platforms always produces a different manifest digest than the source. Setting both at the same time makes charts-syncer fail with a validation error before starting the sync.
+
 ### Sync Helm Charts and Container Images to different registries
 
 By default, charts-syncer syncs Helm Charts packages and their container images to the same registry specified in the `target.repo.url` property. If you require to configure a different destination registry for the images, this can be configured in the `target.containers.url` property:

--- a/api/v1/config.proto
+++ b/api/v1/config.proto
@@ -19,6 +19,10 @@ message Config {
     bool skip_images = 7;
     // Container images to include during sync
     repeated string containers = 8;
+    // Copy charts and container images byte-for-byte so their original digest is preserved.
+    // Not compatible with "container_platforms", since filtering platforms always changes
+    // the resulting manifest digest.
+    bool preserve_digest = 9;
 }
 
 // SourceRepo contains the required information of the source chart repository

--- a/cmd/sync_charts.go
+++ b/cmd/sync_charts.go
@@ -22,6 +22,7 @@ func runChartsSyncer(parentLog log.SectionLogger, c *apiv1.Config) error {
 		chartsyncer.WithLatestVersionOnly(syncLatestVersionOnly),
 		chartsyncer.WithSkipArtifacts(c.GetSkipArtifacts()),
 		chartsyncer.WithSkipImages(c.GetSkipImages()),
+		chartsyncer.WithPreserveDigest(c.GetPreserveDigest()),
 		chartsyncer.WithSkipCharts(c.SkipCharts),
 		chartsyncer.WithUsePlainHTTP(usePlainHTTP),
 

--- a/cmd/sync_containers.go
+++ b/cmd/sync_containers.go
@@ -19,6 +19,7 @@ func runContainersSyncer(parentLog log.SectionLogger, c *apiv1.Config) error {
 		containersyncer.WithInsecure(rootInsecure),
 		containersyncer.WithLatestVersionOnly(syncLatestVersionOnly),
 		containersyncer.WithSkipArtifacts(c.GetSkipArtifacts()),
+		containersyncer.WithPreserveDigest(c.GetPreserveDigest()),
 		containersyncer.WithUsePlainHTTP(usePlainHTTP),
 
 		containersyncer.WithLogger(l),

--- a/gen/proto/v1/config.pb.go
+++ b/gen/proto/v1/config.pb.go
@@ -95,9 +95,13 @@ type Config struct {
 	// Do not sync chart images
 	SkipImages bool `protobuf:"varint,7,opt,name=skip_images,json=skipImages,proto3" json:"skip_images,omitempty"`
 	// Container images to include during sync
-	Containers    []string `protobuf:"bytes,8,rep,name=containers,proto3" json:"containers,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Containers []string `protobuf:"bytes,8,rep,name=containers,proto3" json:"containers,omitempty"`
+	// Copy charts and container images byte-for-byte so their original digest is preserved.
+	// Not compatible with "container_platforms", since filtering platforms always changes
+	// the resulting manifest digest.
+	PreserveDigest bool `protobuf:"varint,9,opt,name=preserve_digest,json=preserveDigest,proto3" json:"preserve_digest,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Config) Reset() {
@@ -184,6 +188,13 @@ func (x *Config) GetContainers() []string {
 		return x.Containers
 	}
 	return nil
+}
+
+func (x *Config) GetPreserveDigest() bool {
+	if x != nil {
+		return x.PreserveDigest
+	}
+	return false
 }
 
 // SourceRepo contains the required information of the source chart repository
@@ -564,7 +575,7 @@ var File_v1_config_proto protoreflect.FileDescriptor
 
 const file_v1_config_proto_rawDesc = "" +
 	"\n" +
-	"\x0fv1/config.proto\x12\x03api\"\xa4\x02\n" +
+	"\x0fv1/config.proto\x12\x03api\"\xcd\x02\n" +
 	"\x06Config\x12#\n" +
 	"\x06source\x18\x01 \x01(\v2\v.api.SourceR\x06source\x12#\n" +
 	"\x06target\x18\x02 \x01(\v2\v.api.TargetR\x06target\x12\x16\n" +
@@ -577,7 +588,8 @@ const file_v1_config_proto_rawDesc = "" +
 	"skipImages\x12\x1e\n" +
 	"\n" +
 	"containers\x18\b \x03(\tR\n" +
-	"containers\"X\n" +
+	"containers\x12'\n" +
+	"\x0fpreserve_digest\x18\t \x01(\bR\x0epreserveDigest\"X\n" +
 	"\x06Source\x12\x1d\n" +
 	"\x04repo\x18\x01 \x01(\v2\t.api.RepoR\x04repo\x12/\n" +
 	"\n" +

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.20.1
 	github.com/stretchr/testify v1.11.1
-	github.com/vmware-labs/distribution-tooling-for-helm v0.8.0
+	github.com/vmware-labs/distribution-tooling-for-helm v0.9.0
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.20.2

--- a/go.sum
+++ b/go.sum
@@ -679,8 +679,8 @@ github.com/transparency-dev/merkle v0.0.2 h1:Q9nBoQcZcgPamMkGn7ghV8XiTZ/kRxn1yCG
 github.com/transparency-dev/merkle v0.0.2/go.mod h1:pqSy+OXefQ1EDUVmAJ8MUhHB9TXGuzVAT58PqBoHz1A=
 github.com/vbatts/tar-split v0.12.1 h1:CqKoORW7BUWBe7UL/iqTVvkTBOF8UvOMKOIZykxnnbo=
 github.com/vbatts/tar-split v0.12.1/go.mod h1:eF6B6i6ftWQcDqEn3/iGFRFRo8cBIMSJVOpnNdfTMFA=
-github.com/vmware-labs/distribution-tooling-for-helm v0.8.0 h1:scxTBFDsWe8MtLm8HPziOxlTLVQf9+/7DK1Ntke3UK8=
-github.com/vmware-labs/distribution-tooling-for-helm v0.8.0/go.mod h1:Q6WupfRDDMi6qBcta2IK6UUAt14xe64ug8kLRfiuImY=
+github.com/vmware-labs/distribution-tooling-for-helm v0.9.0 h1:DCjcJ9lq4Bx97/2MVGitC8d5H3Y7TwPSnt9aTfJU/7M=
+github.com/vmware-labs/distribution-tooling-for-helm v0.9.0/go.mod h1:Q6WupfRDDMi6qBcta2IK6UUAt14xe64ug8kLRfiuImY=
 github.com/vmware-labs/yaml-jsonpath v0.3.2 h1:/5QKeCBGdsInyDCyVNLbXyilb61MXGi9NP674f9Hobk=
 github.com/vmware-labs/yaml-jsonpath v0.3.2/go.mod h1:U6whw1z03QyqgWdgXxvVnQ90zN1BWz5V+51Ewf8k+rQ=
 github.com/vmware-tanzu/carvel-imgpkg v0.38.3 h1:vVnqCPFEZ2NQcoTywg/va91qRyCuu46wBYAETqoyez4=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -124,6 +124,10 @@ func Load(config *apiv1.Config) error {
 		return errors.New("\"charts\" and \"skipCharts\" properties can not be set at the same time")
 	}
 
+	if config.GetPreserveDigest() && len(config.GetContainerPlatforms()) > 0 {
+		return errors.New("\"preserveDigest\" and \"containerPlatforms\" properties can not be set at the same time: filtering container platforms always changes the resulting manifest digest")
+	}
+
 	return nil
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,6 +33,22 @@ func TestLoad(t *testing.T) {
 	}
 }
 
+// preserveDigest and containerPlatforms are mutually exclusive: filtering
+// platforms always changes the resulting manifest digest.
+func TestLoadPreserveDigestConflict(t *testing.T) {
+	var syncConfig apiv1.Config
+	cfgFile := "../../testdata/example-config-preserve-digest-conflict.yaml"
+	viper.SetConfigFile(cfgFile)
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatalf("error reading config file: %+v", err)
+	}
+	err := Load(&syncConfig)
+	if err == nil {
+		t.Fatalf("expected error loading config file, got nil")
+	}
+	assert.Contains(t, err.Error(), "\"preserveDigest\" and \"containerPlatforms\" properties can not be set at the same time")
+}
+
 // Get auth properties from env vars
 func TestGetAuthFromEnvVar(t *testing.T) {
 	tests := map[string]struct {

--- a/pkg/chartsyncer/sync.go
+++ b/pkg/chartsyncer/sync.go
@@ -3,9 +3,11 @@ package chartsyncer
 import (
 	goerrors "errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 
+	apiv1 "github.com/bitnami/charts-syncer/gen/proto/v1"
 	"github.com/bitnami/charts-syncer/pkg/client/config"
 	"github.com/juju/errors"
 	log "github.com/vmware-labs/distribution-tooling-for-helm/pkg/dtlog"
@@ -14,6 +16,26 @@ import (
 
 // ErrNoChartsToSync is returned when there are no charts to sync
 var ErrNoChartsToSync = errors.New("no charts to sync")
+
+// preservedSourceRef returns the bare oci:// reference for chartName in the
+// syncer's source repo, or "" if the source isn't an OCI registry.
+//
+// charts-syncer always fetches ch.TgzPath to a local file before wrapping
+// (needed to inspect the chart for indexing/dependency resolution), so
+// WrapChart never sees an oci:// inputPath on its own. Passing this
+// alongside the local tgz lets the wrap library still capture the pristine
+// source manifest for PreserveDigest, instead of only the tgz bytes.
+func (s *Syncer) preservedSourceRef(chartName string) string {
+	repo := s.source.GetRepo()
+	if repo.GetKind() != apiv1.Kind_OCI {
+		return ""
+	}
+	u, err := url.Parse(repo.GetUrl())
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("oci://%s%s/%s", u.Host, u.Path, chartName)
+}
 
 func (s *Syncer) syncChart(ch *Chart, l log.SectionLogger) error {
 	id := fmt.Sprintf("%s-%s", ch.Name, ch.Version)
@@ -38,11 +60,18 @@ func (s *Syncer) syncChart(ch *Chart, l log.SectionLogger) error {
 		Version: ch.Version,
 	}
 
-	wrappedChartPath, err := s.cli.src.WrapChart(ch.TgzPath,
-		filepath.Join(workdir, "wraps", fmt.Sprintf("%s-%s.wrap.tgz", ch.Name, ch.Version)),
+	wrapOpts := []config.Option{
 		config.WithLogger(l), config.WithWorkDir(workdir),
 		config.WithContainerPlatforms(s.containerPlatforms), config.WithSkipArtifacts(s.skipArtifacts),
-		config.WithSkipImages(s.skipImages),
+		config.WithSkipImages(s.skipImages), config.WithPreserveDigest(s.preserveDigest),
+	}
+	if s.preserveDigest {
+		wrapOpts = append(wrapOpts, config.WithPreservedSourceRef(s.preservedSourceRef(ch.Name)))
+	}
+
+	wrappedChartPath, err := s.cli.src.WrapChart(ch.TgzPath,
+		filepath.Join(workdir, "wraps", fmt.Sprintf("%s-%s.wrap.tgz", ch.Name, ch.Version)),
+		wrapOpts...,
 	)
 	if err != nil {
 		return errors.Annotatef(err, "unable to move chart %q with charts-syncer", id)
@@ -53,7 +82,13 @@ func (s *Syncer) syncChart(ch *Chart, l log.SectionLogger) error {
 		return nil
 	}
 
-	if err := s.cli.dst.UnwrapChart(wrappedChartPath, metadata, config.WithLogger(l), config.WithWorkDir(workdir), config.WithSkipImages(s.skipImages)); err != nil {
+	if err := s.cli.dst.UnwrapChart(
+		wrappedChartPath, metadata,
+		config.WithLogger(l),
+		config.WithWorkDir(workdir),
+		config.WithSkipImages(s.skipImages),
+		config.WithPreserveDigest(s.preserveDigest),
+	); err != nil {
 		l.Errorf("unable to upload %q chart: %+v", id, err)
 		return errors.Trace(err)
 	}

--- a/pkg/chartsyncer/syncer.go
+++ b/pkg/chartsyncer/syncer.go
@@ -51,6 +51,9 @@ type Syncer struct {
 	// skip syncing images
 	skipImages bool
 
+	// copy charts and container images byte-for-byte, preserving their original digest
+	preserveDigest bool
+
 	// Storage directory for required artifacts
 	workdir string
 
@@ -108,6 +111,14 @@ func WithSkipArtifacts(skip bool) Option {
 func WithSkipImages(skip bool) Option {
 	return func(s *Syncer) {
 		s.skipImages = skip
+	}
+}
+
+// WithPreserveDigest configures the syncer to copy charts and container images
+// byte-for-byte, preserving their original digest
+func WithPreserveDigest(preserve bool) Option {
+	return func(s *Syncer) {
+		s.preserveDigest = preserve
 	}
 }
 

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	ContainerPlatforms []string
 	SkipArtifacts      bool
 	SkipImages         bool
+	PreserveDigest     bool
+	PreservedSourceRef string
 }
 
 // Option is a function that modifies the Config
@@ -43,6 +45,22 @@ func WithSkipImages(skipImages bool) func(*Config) {
 func WithContainerPlatforms(containerPlatforms []string) func(*Config) {
 	return func(c *Config) {
 		c.ContainerPlatforms = containerPlatforms
+	}
+}
+
+// WithPreserveDigest sets the preserve digest flag
+func WithPreserveDigest(preserveDigest bool) func(*Config) {
+	return func(c *Config) {
+		c.PreserveDigest = preserveDigest
+	}
+}
+
+// WithPreservedSourceRef sets the original oci:// reference of the chart
+// being wrapped, so PreserveDigest can capture the pristine source manifest
+// even though the chart was already fetched to a local .tgz for indexing
+func WithPreservedSourceRef(ref string) func(*Config) {
+	return func(c *Config) {
+		c.PreservedSourceRef = ref
 	}
 }
 

--- a/pkg/client/source/common/common.go
+++ b/pkg/client/source/common/common.go
@@ -72,6 +72,8 @@ func (t *Source) WrapChart(tgz, destWrap string, opts ...config.Option) (string,
 		wrap.WithPlatforms(cfg.ContainerPlatforms),
 		wrap.WithContainerRegistryAuth(t.containersUsername, t.containersPassword),
 		wrap.WithOutputFile(destWrap),
+		wrap.WithPreserveDigest(cfg.PreserveDigest),
+		wrap.WithPreservedSourceRef(cfg.PreservedSourceRef),
 		wrap.WithLogger(l))
 	if err != nil {
 		return "", fmt.Errorf("failed to wrap chart %q: %w", tgz, err)
@@ -99,6 +101,7 @@ func (t *Source) WrapContainer(imageRef string, destination string, opts ...conf
 		wrap.WithContainerRegistryAuth(t.containersUsername, t.containersPassword),
 		wrap.WithPlatforms(cfg.ContainerPlatforms),
 		wrap.WithOutputFile(destination),
+		wrap.WithPreserveDigest(cfg.PreserveDigest),
 		wrap.WithLogger(l),
 	)
 	if err != nil {

--- a/pkg/client/target/common/common.go
+++ b/pkg/client/target/common/common.go
@@ -100,6 +100,7 @@ func (t *Target) UnwrapChart(file string, _ *chart.Metadata, opts ...config.Opti
 		unwrap.WithSkipImageRelocation(cfg.SkipImages),
 		unwrap.WithSkipPullImages(cfg.SkipImages),
 		unwrap.WithPreserveRepository(false),
+		unwrap.WithPreserveDigest(cfg.PreserveDigest),
 	); err != nil {
 		return errors.Trace(err)
 	}
@@ -128,6 +129,7 @@ func (t *Target) UnwrapContainer(file string, opts ...config.Option) error {
 		unwrap.WithSkipPullImages(cfg.SkipImages),
 		unwrap.WithFetchArtifacts(!cfg.SkipArtifacts),
 		unwrap.WithPreserveRepository(false),
+		unwrap.WithPreserveDigest(cfg.PreserveDigest),
 	); err != nil {
 		return errors.Trace(err)
 	}

--- a/pkg/containersyncer/sync.go
+++ b/pkg/containersyncer/sync.go
@@ -35,6 +35,7 @@ func (s *Syncer) syncContainer(c *types.ContainerImage, tag string, l log.Sectio
 		config.WithLogger(l), config.WithWorkDir(workdir),
 		config.WithContainerPlatforms(s.containerPlatforms),
 		config.WithSkipArtifacts(s.skipArtifacts),
+		config.WithPreserveDigest(s.preserveDigest),
 	)
 	if err != nil {
 		return errors.Annotatef(err, "unable to move container %q with charts-syncer", id)
@@ -47,7 +48,7 @@ func (s *Syncer) syncContainer(c *types.ContainerImage, tag string, l log.Sectio
 		return nil
 	}
 
-	if err := s.cli.dst.UnwrapContainer(wrappedContainerPath, config.WithLogger(l), config.WithWorkDir(workdir)); err != nil {
+	if err := s.cli.dst.UnwrapContainer(wrappedContainerPath, config.WithLogger(l), config.WithWorkDir(workdir), config.WithPreserveDigest(s.preserveDigest)); err != nil {
 		l.Errorf("unable to upload %q container: %+v", id, err)
 		return errors.Trace(err)
 	}

--- a/pkg/containersyncer/syncer.go
+++ b/pkg/containersyncer/syncer.go
@@ -40,6 +40,9 @@ type Syncer struct {
 	// skip syncing artifacts
 	skipArtifacts bool
 
+	// copy container images byte-for-byte, preserving their original digest
+	preserveDigest bool
+
 	// Storage directory for required artifacts
 	workdir string
 
@@ -150,5 +153,13 @@ func New(source *apiv1.Source, target *apiv1.Target, opts ...Option) (*Syncer, e
 func WithContainerPlatforms(platforms []string) Option {
 	return func(s *Syncer) {
 		s.containerPlatforms = platforms
+	}
+}
+
+// WithPreserveDigest configures the syncer to copy container images byte-for-byte,
+// preserving their original digest
+func WithPreserveDigest(preserve bool) Option {
+	return func(s *Syncer) {
+		s.preserveDigest = preserve
 	}
 }

--- a/testdata/example-config-preserve-digest-conflict.yaml
+++ b/testdata/example-config-preserve-digest-conflict.yaml
@@ -1,0 +1,15 @@
+#
+# Example config file with conflicting preserveDigest/containerPlatforms properties
+#
+source:
+  repo:
+    kind: HELM
+    url: http://localhost:8080 # local test source repo
+target:
+  repo:
+    kind: CHARTMUSEUM
+    url: http://localhost:9090 # local test target repo
+
+preserveDigest: true
+containerPlatforms:
+  - linux/amd64


### PR DESCRIPTION
## Summary

Adds a preserveDigest config option that copies charts and container images byte-for-byte during sync, so the destination digest (and any signature made against it) matches the source exactly — instead of the current behavior of unpacking/rebuilding artifacts, which changes their manifest digest.

## Changes

- New preserve_digest field on Config proto (`api/v1/config.proto`, regenerated `gen/proto/v1/config.pb.go`).
- Wires `preserveDigest` through both sync paths:
  - chartsyncer: `WithPreserveDigest` option, passed into WrapChart/UnwrapChart.
  - containersyncer: `WithPreserveDigest` option, passed into WrapContainer/UnwrapContainer.
- For OCI sources, syncChart now also resolves and passes the original oci:// source ref (preservedSourceRef) alongside the local .tgz, since charts are always fetched locally before wrapping and the wrap step otherwise only sees the local file — losing the pristine source manifest needed to preserve its digest.
- Validation: preserveDigest and containerPlatforms are mutually exclusive (filtering platforms always changes the resulting digest); internal/config.Load now rejects configs that set both, with a test (TestLoadPreserveDigestConflict).
- Bumps github.com/vmware-labs/distribution-tooling-for-helm v0.8.0 → v0.9.0 (adds the underlying wrap.WithPreserveDigest / unwrap.WithPreserveDigest / wrap.WithPreservedSourceRef support this feature depends on).
- README: new "Preserve the original digest of charts and container images" section with example config and the platform-filter incompatibility note.

## Testing

- TestLoadPreserveDigestConflict covers the new validation error path.

## Related issues

Fixes https://github.com/bitnami/charts-syncer/issues/369