### PR TITLE
ci: move Docker image build and push to GitHub Enterprise

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,9 +8,6 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
-    env:
-      dockerhub_image_name: docker.io/bitnami/charts-syncer
-      ghcr_image_name: ghcr.io/bitnami/charts-syncer
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -26,11 +23,6 @@ jobs:
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version: '^1.26'
-      # Setup env for multi-arch builds
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       # Build binaries
       - name: Release
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
@@ -39,40 +31,3 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      # Build & Publish multi-arch image
-      - name: Login to Docker Hub
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
-        with:
-          username: ${{ secrets.BITNAMI_USERNAME }}
-          password: ${{ secrets.BITNAMI_PASSWORD }}
-      - name: Login to GHRC
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract image metadata (tags, labels)
-        id: metadata
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: |
-            ${{ env.dockerhub_image_name }}
-            ${{ env.ghcr_image_name }}
-          # Image tags: 'latest', '2' and the tagged version without the 'v' prefix
-          tags: |
-            type=raw,value=2
-            type=raw,value=${{ env.VERSION_TAG }}
-            type=raw,value=latest
-      - name: Build and push image
-        id: docker_build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        env:
-          # Disable attestation to prevent 'unknown/unknown' artifacts in GHCR
-          BUILDX_NO_DEFAULT_ATTESTATIONS: 1
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}


### PR DESCRIPTION
## Description

Moves the Docker image build and push out of this public repo's CI. It
previously used long-lived credentials (`BITNAMI_USERNAME`/`BITNAMI_PASSWORD`)
stored as repo secrets to push to Docker Hub, plus a GHCR push using the
repo's own token. That build and push is now handled by a private workflow
that clones this repo at each release tag and publishes to
`ghcr.io/bitnami/charts-syncer` from there instead, so no long-lived
credential needs to live in this public repo.

Source code and the release process for GitHub Releases (via GoReleaser)
are unaffected and remain here as before - only the Docker Hub/GHCR
build+push steps move out.

## Changes

- `release.yaml`: removed the QEMU/Buildx setup, Docker Hub login, GHCR
  login, image metadata extraction, and build-and-push steps. Kept the
  Checkout/Unshallow/version/Go setup/GoReleaser steps unchanged.
- Docker Hub publishing is discontinued from this repo's own CI going
  forward (not migrated elsewhere) - GHCR remains the distribution point
  for this image.

## Testing

The replacement build+push workflow was verified independently: triggered
manually against the current latest tag, and confirmed via GHCR's registry
API that a real multi-arch (`linux/amd64`, `linux/arm64`) image was
produced and pushed successfully.

Once this is merged, the `BITNAMI_USERNAME`, `BITNAMI_PASSWORD`, and an
unused `GCR_JSON_KEY` secret will be removed from this repo's settings.