### PR TITLE
feat: expose a flag to control timeout on helm/oci pulls

### DIFF
--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	goerrors "errors"
+	"time"
 
 	apiv1 "github.com/bitnami/charts-syncer/gen/proto/v1"
 	"github.com/bitnami/charts-syncer/internal/config"
 	klogLogger "github.com/bitnami/charts-syncer/internal/log"
+	"github.com/bitnami/charts-syncer/internal/utils"
 	"github.com/juju/errors"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -21,6 +23,7 @@ var (
 	syncLatestVersionOnly bool
 	usePlainHTTP          bool
 	usePlainLog           bool
+	syncTimeout           time.Duration
 )
 
 var syncExample = `
@@ -81,6 +84,7 @@ func newSyncCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&usePlainHTTP, "use-plain-http", false, "Use plain HTTP instead of HTTPS")
 	cmd.Flags().BoolVar(&usePlainLog, "use-plain-log", false, "Use plain klog instead of the pretty logging")
 	cmd.Flags().StringVar(&syncFromDate, "from-date", "", "Date you want to synchronize charts from. Format: YYYY-MM-DD")
+	cmd.Flags().DurationVar(&syncTimeout, "timeout", 0, "Timeout for chart and container syncing operations (e.g. 5m, 300s)")
 
 	return cmd
 }
@@ -103,6 +107,13 @@ func hasContainerTarget(c *apiv1.Config) bool {
 
 func runSync(parentLog log.SectionLogger, c *apiv1.Config) error {
 	var errs error
+
+	if syncTimeout > 0 {
+		klog.V(3).Infof("Setting global HTTP client timeout to %v", syncTimeout)
+		utils.DefaultClient.Timeout = syncTimeout
+		utils.InsecureClient.Timeout = syncTimeout
+	}
+
 	if hasChartSource(c) && hasChartTarget(c) {
 		if err := runChartsSyncer(parentLog, c); err != nil {
 			errs = goerrors.Join(errs, err)

--- a/cmd/sync_charts.go
+++ b/cmd/sync_charts.go
@@ -25,6 +25,7 @@ func runChartsSyncer(parentLog log.SectionLogger, c *apiv1.Config) error {
 		chartsyncer.WithPreserveDigest(c.GetPreserveDigest()),
 		chartsyncer.WithSkipCharts(c.SkipCharts),
 		chartsyncer.WithUsePlainHTTP(usePlainHTTP),
+		chartsyncer.WithTimeout(syncTimeout),
 
 		chartsyncer.WithLogger(l),
 	}

--- a/cmd/sync_containers.go
+++ b/cmd/sync_containers.go
@@ -21,6 +21,7 @@ func runContainersSyncer(parentLog log.SectionLogger, c *apiv1.Config) error {
 		containersyncer.WithSkipArtifacts(c.GetSkipArtifacts()),
 		containersyncer.WithPreserveDigest(c.GetPreserveDigest()),
 		containersyncer.WithUsePlainHTTP(usePlainHTTP),
+		containersyncer.WithTimeout(syncTimeout),
 
 		containersyncer.WithLogger(l),
 	}

--- a/pkg/chartsyncer/sync.go
+++ b/pkg/chartsyncer/sync.go
@@ -64,6 +64,7 @@ func (s *Syncer) syncChart(ch *Chart, l log.SectionLogger) error {
 		config.WithLogger(l), config.WithWorkDir(workdir),
 		config.WithContainerPlatforms(s.containerPlatforms), config.WithSkipArtifacts(s.skipArtifacts),
 		config.WithSkipImages(s.skipImages), config.WithPreserveDigest(s.preserveDigest),
+		config.WithTimeout(s.timeout),
 	}
 	if s.preserveDigest {
 		wrapOpts = append(wrapOpts, config.WithPreservedSourceRef(s.preservedSourceRef(ch.Name)))
@@ -86,6 +87,7 @@ func (s *Syncer) syncChart(ch *Chart, l log.SectionLogger) error {
 		wrappedChartPath, metadata,
 		config.WithLogger(l),
 		config.WithWorkDir(workdir),
+		config.WithTimeout(s.timeout),
 		config.WithSkipImages(s.skipImages),
 		config.WithPreserveDigest(s.preserveDigest),
 	); err != nil {

--- a/pkg/chartsyncer/syncer.go
+++ b/pkg/chartsyncer/syncer.go
@@ -3,6 +3,7 @@ package chartsyncer
 
 import (
 	"os"
+	"time"
 
 	apiv1 "github.com/bitnami/charts-syncer/gen/proto/v1"
 	"github.com/bitnami/charts-syncer/pkg/client"
@@ -56,6 +57,9 @@ type Syncer struct {
 
 	// Storage directory for required artifacts
 	workdir string
+
+	// Timeout for operations
+	timeout time.Duration
 
 	logger log.SectionLogger
 }
@@ -129,6 +133,13 @@ func WithWorkdir(dir string) Option {
 	}
 }
 
+// WithTimeout configures the syncer to use a specific timeout.
+func WithTimeout(timeout time.Duration) Option {
+	return func(s *Syncer) {
+		s.timeout = timeout
+	}
+}
+
 // WithInsecure configures the syncer to allow insecure SSL connections
 func WithInsecure(enable bool) Option {
 	return func(s *Syncer) {
@@ -168,7 +179,7 @@ func New(source *apiv1.Source, target *apiv1.Target, opts ...Option) (*Syncer, e
 
 	s.cli = &Clients{}
 	if source.GetRepo() != nil {
-		srcCli, err := cs.NewClient(source, types.WithCache(s.workdir), types.WithInsecure(s.insecure), types.WithUsePlainHTTP(s.usePlainHTTP))
+		srcCli, err := cs.NewClient(source, types.WithCache(s.workdir), types.WithInsecure(s.insecure), types.WithUsePlainHTTP(s.usePlainHTTP), types.WithTimeout(s.timeout))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -178,7 +189,7 @@ func New(source *apiv1.Source, target *apiv1.Target, opts ...Option) (*Syncer, e
 	}
 
 	if target.GetRepo() != nil {
-		dstCli, err := ct.NewClient(target, types.WithCache(s.workdir), types.WithInsecure(s.insecure), types.WithUsePlainHTTP(s.usePlainHTTP))
+		dstCli, err := ct.NewClient(target, types.WithCache(s.workdir), types.WithInsecure(s.insecure), types.WithUsePlainHTTP(s.usePlainHTTP), types.WithTimeout(s.timeout))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/pkg/client/config/config.go
+++ b/pkg/client/config/config.go
@@ -2,6 +2,8 @@
 package config
 
 import (
+	"time"
+
 	log "github.com/vmware-labs/distribution-tooling-for-helm/pkg/dtlog"
 	"github.com/vmware-labs/distribution-tooling-for-helm/pkg/dtlog/silent"
 )
@@ -15,6 +17,7 @@ type Config struct {
 	SkipImages         bool
 	PreserveDigest     bool
 	PreservedSourceRef string
+	Timeout            time.Duration
 }
 
 // Option is a function that modifies the Config
@@ -68,6 +71,13 @@ func WithPreservedSourceRef(ref string) func(*Config) {
 func WithLogger(logger log.SectionLogger) func(*Config) {
 	return func(c *Config) {
 		c.Logger = logger
+	}
+}
+
+// WithTimeout sets the timeout for network operations
+func WithTimeout(timeout time.Duration) func(*Config) {
+	return func(c *Config) {
+		c.Timeout = timeout
 	}
 }
 

--- a/pkg/client/repo/core.go
+++ b/pkg/client/repo/core.go
@@ -28,6 +28,7 @@ func NewClient(repo *apiv1.Repo, opts ...types.Option) (client.ChartsReaderWrite
 
 	insecure := copts.GetInsecure()
 	usePlainHTTP := copts.GetUsePlainHTTP()
+	timeout := copts.GetTimeout()
 	// Define cache dir if it hasn't been provided
 	cacheDir := copts.GetCache()
 	if cacheDir == "" {
@@ -49,7 +50,7 @@ func NewClient(repo *apiv1.Repo, opts ...types.Option) (client.ChartsReaderWrite
 	case apiv1.Kind_HARBOR:
 		return harbor.New(repo, c, insecure)
 	case apiv1.Kind_OCI:
-		return oci.New(repo, c, insecure, usePlainHTTP)
+		return oci.New(repo, c, insecure, usePlainHTTP, timeout)
 	case apiv1.Kind_LOCAL:
 		return local.New(repo.Path)
 	default:
@@ -66,6 +67,7 @@ func NewContainerClient(containers *apiv1.Containers, opts ...types.Option) (cli
 
 	insecure := copts.GetInsecure()
 	usePlainHTTP := copts.GetUsePlainHTTP()
+	timeout := copts.GetTimeout()
 	// Define cache dir if it hasn't been provided
 	cacheDir := copts.GetCache()
 	if cacheDir == "" {
@@ -87,5 +89,5 @@ func NewContainerClient(containers *apiv1.Containers, opts ...types.Option) (cli
 	}
 	resolver := oci.NewDockerResolver(u, containers.GetAuth().GetUsername(), containers.GetAuth().GetPassword(), insecure)
 
-	return oci.NewRaw(u, containers.GetAuth().GetUsername(), containers.GetAuth().GetPassword(), c, insecure, usePlainHTTP, entries, resolver)
+	return oci.NewRaw(u, containers.GetAuth().GetUsername(), containers.GetAuth().GetPassword(), c, insecure, usePlainHTTP, entries, resolver, timeout)
 }

--- a/pkg/client/repo/oci/oci.go
+++ b/pkg/client/repo/oci/oci.go
@@ -59,6 +59,7 @@ type Repo struct {
 	entries        map[string][]string
 	cache          cache.Cacher
 	dockerResolver remotes.Resolver
+	timeout        time.Duration
 }
 
 // Tags contains the tags for a specific OCI artifact
@@ -68,7 +69,7 @@ type Tags struct {
 }
 
 // New creates a Repo object from an apiv1.Repo object.
-func New(repo *apiv1.Repo, c cache.Cacher, insecure bool, usePlainHTTP bool) (*Repo, error) {
+func New(repo *apiv1.Repo, c cache.Cacher, insecure bool, usePlainHTTP bool, timeout time.Duration) (*Repo, error) {
 	// Init entries
 	entries, err := populateEntries(repo, usePlainHTTP)
 	if err != nil {
@@ -81,13 +82,13 @@ func New(repo *apiv1.Repo, c cache.Cacher, insecure bool, usePlainHTTP bool) (*R
 	}
 	resolver := NewDockerResolver(u, repo.GetAuth().GetUsername(), repo.GetAuth().GetPassword(), insecure)
 
-	return NewRaw(u, repo.GetAuth().GetUsername(), repo.GetAuth().GetPassword(), c, insecure, usePlainHTTP, entries, resolver)
+	return NewRaw(u, repo.GetAuth().GetUsername(), repo.GetAuth().GetPassword(), c, insecure, usePlainHTTP, entries, resolver, timeout)
 
 }
 
 // NewRaw creates a Repo object.
-func NewRaw(u *url.URL, user string, pass string, c cache.Cacher, insecure bool, usePlainHTTP bool, entries map[string][]string, resolver remotes.Resolver) (*Repo, error) {
-	return &Repo{url: u, username: user, password: pass, cache: c, insecure: insecure, usePlainHTTP: usePlainHTTP, entries: entries, dockerResolver: resolver}, nil
+func NewRaw(u *url.URL, user string, pass string, c cache.Cacher, insecure bool, usePlainHTTP bool, entries map[string][]string, resolver remotes.Resolver, timeout time.Duration) (*Repo, error) {
+	return &Repo{url: u, username: user, password: pass, cache: c, insecure: insecure, usePlainHTTP: usePlainHTTP, entries: entries, dockerResolver: resolver, timeout: timeout}, nil
 }
 
 // List lists all chart names in a repo
@@ -126,6 +127,11 @@ func (r *Repo) getTagManifest(chartName, version string) (*ocispec.Manifest, err
 		transportKind := http.DefaultTransport.(*http.Transport).Clone()
 		transportKind.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
 		opts = append(opts, remote.WithTransport(transportKind))
+	}
+	if r.timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		defer cancel()
+		opts = append(opts, remote.WithContext(ctx))
 	}
 
 	image, err := remote.Image(ref, opts...)
@@ -193,6 +199,11 @@ func (r *Repo) ListChartVersions(chartName string) ([]string, error) {
 		transportKind.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
 		opts = append(opts, remote.WithTransport(transportKind))
 	}
+	if r.timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		defer cancel()
+		opts = append(opts, remote.WithContext(ctx))
+	}
 
 	tags, err := remote.List(repo, opts...)
 	if err != nil {
@@ -246,6 +257,11 @@ func (r *Repo) ListContainerTags(containerName string) ([]string, error) {
 		transportKind := http.DefaultTransport.(*http.Transport).Clone()
 		transportKind.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
 		opts = append(opts, remote.WithTransport(transportKind))
+	}
+	if r.timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		defer cancel()
+		opts = append(opts, remote.WithContext(ctx))
 	}
 
 	tags, err := remote.List(repo, opts...)
@@ -309,6 +325,11 @@ func (r *Repo) Fetch(chartName string, version string) (string, error) {
 		transportKind := http.DefaultTransport.(*http.Transport).Clone()
 		transportKind.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
 		opts = append(opts, remote.WithTransport(transportKind))
+	}
+	if r.timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		defer cancel()
+		opts = append(opts, remote.WithContext(ctx))
 	}
 
 	img, err := remote.Image(ref, opts...)
@@ -382,6 +403,11 @@ func (r *Repo) HasContainer(imageName string, tag string) (bool, error) {
 		transportKind.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
 		opts = append(opts, remote.WithTransport(transportKind))
 	}
+	if r.timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		defer cancel()
+		opts = append(opts, remote.WithContext(ctx))
+	}
 
 	_, err = remote.Head(ref, opts...)
 	if err != nil {
@@ -417,6 +443,11 @@ func (r *Repo) Has(chartName string, version string) (bool, error) {
 		transportKind := http.DefaultTransport.(*http.Transport).Clone()
 		transportKind.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} // #nosec G402
 		opts = append(opts, remote.WithTransport(transportKind))
+	}
+	if r.timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
+		defer cancel()
+		opts = append(opts, remote.WithContext(ctx))
 	}
 
 	_, err = remote.Head(ref, opts...)

--- a/pkg/client/repo/oci/ocitester.go
+++ b/pkg/client/repo/oci/ocitester.go
@@ -135,7 +135,7 @@ func PrepareTest(t *testing.T, ociRepo *apiv1.Repo) *Repo {
 	t.Cleanup(func() { os.RemoveAll(cacheDir) })
 
 	// Create oci client
-	client, err := New(ociRepo, cache, false, true)
+	client, err := New(ociRepo, cache, false, true, 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/client/source/common/common.go
+++ b/pkg/client/source/common/common.go
@@ -2,6 +2,7 @@
 package common
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -64,9 +65,11 @@ func (t *Source) WrapChart(tgz, destWrap string, opts ...config.Option) (string,
 
 	fetchArtifacts := !cfg.SkipArtifacts
 
-	outputFile, err := wrap.Chart(tgz, wrap.WithFetchArtifacts(fetchArtifacts),
+	wrapOpts := []wrap.Option{
+		wrap.WithFetchArtifacts(fetchArtifacts),
 		wrap.WithSkipPullImages(cfg.SkipImages),
-		wrap.WithInsecure(t.insecure), wrap.WithTempDirectory(wrapWorkdir),
+		wrap.WithInsecure(t.insecure),
+		wrap.WithTempDirectory(wrapWorkdir),
 		wrap.WithUsePlainHTTP(t.usePlainHTTP),
 		wrap.WithAuth(t.username, t.password),
 		wrap.WithPlatforms(cfg.ContainerPlatforms),
@@ -74,7 +77,16 @@ func (t *Source) WrapChart(tgz, destWrap string, opts ...config.Option) (string,
 		wrap.WithOutputFile(destWrap),
 		wrap.WithPreserveDigest(cfg.PreserveDigest),
 		wrap.WithPreservedSourceRef(cfg.PreservedSourceRef),
-		wrap.WithLogger(l))
+		wrap.WithLogger(l),
+	}
+
+	if cfg.Timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+		defer cancel()
+		wrapOpts = append(wrapOpts, wrap.WithContext(ctx))
+	}
+
+	outputFile, err := wrap.Chart(tgz, wrapOpts...)
 	if err != nil {
 		return "", fmt.Errorf("failed to wrap chart %q: %w", tgz, err)
 	}
@@ -92,7 +104,7 @@ func (t *Source) WrapContainer(imageRef string, destination string, opts ...conf
 	}
 	defer os.RemoveAll(wrapWorkdir)
 
-	outputFile, err := wrap.Container(imageRef,
+	wrapOpts := []wrap.Option{
 		wrap.WithFetchArtifacts(!cfg.SkipArtifacts),
 		wrap.WithSkipPullImages(cfg.SkipImages),
 		wrap.WithInsecure(t.insecure),
@@ -103,7 +115,15 @@ func (t *Source) WrapContainer(imageRef string, destination string, opts ...conf
 		wrap.WithOutputFile(destination),
 		wrap.WithPreserveDigest(cfg.PreserveDigest),
 		wrap.WithLogger(l),
-	)
+	}
+
+	if cfg.Timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+		defer cancel()
+		wrapOpts = append(wrapOpts, wrap.WithContext(ctx))
+	}
+
+	outputFile, err := wrap.Container(imageRef, wrapOpts...)
 	if err != nil {
 		return "", fmt.Errorf("failed to wrap container %q: %w", imageRef, err)
 	}

--- a/pkg/client/target/common/common.go
+++ b/pkg/client/target/common/common.go
@@ -2,6 +2,7 @@
 package common
 
 import (
+	"context"
 	"os"
 	"regexp"
 
@@ -91,17 +92,27 @@ func (t *Target) UnwrapChart(file string, _ *chart.Metadata, opts ...config.Opti
 
 	defer os.RemoveAll(wrapWorkdir)
 
-	if _, err := unwrap.Chart(file, t.getContainersUploadURL(), t.GetUploadURL(), unwrap.WithSayYes(true),
+	unwrapOpts := []unwrap.Option{
+		unwrap.WithSayYes(true),
 		unwrap.WithTempDirectory(wrapWorkdir),
 		unwrap.WithUsePlainHTTP(t.usePlainHTTP),
 		unwrap.WithLogger(cfg.Logger),
-		unwrap.WithAuth(t.username, t.password), unwrap.WithInsecure(t.insecure),
+		unwrap.WithAuth(t.username, t.password),
+		unwrap.WithInsecure(t.insecure),
 		unwrap.WithContainerRegistryAuth(t.containersUsername, t.containersPassword),
 		unwrap.WithSkipImageRelocation(cfg.SkipImages),
 		unwrap.WithSkipPullImages(cfg.SkipImages),
 		unwrap.WithPreserveRepository(false),
 		unwrap.WithPreserveDigest(cfg.PreserveDigest),
-	); err != nil {
+	}
+
+	if cfg.Timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+		defer cancel()
+		unwrapOpts = append(unwrapOpts, unwrap.WithContext(ctx))
+	}
+
+	if _, err := unwrap.Chart(file, t.getContainersUploadURL(), t.GetUploadURL(), unwrapOpts...); err != nil {
 		return errors.Trace(err)
 	}
 	return nil
@@ -119,18 +130,28 @@ func (t *Target) UnwrapContainer(file string, opts ...config.Option) error {
 
 	defer os.RemoveAll(wrapWorkdir)
 
-	if _, err := unwrap.Container(file, t.getContainersUploadURL(), unwrap.WithSayYes(true),
+	unwrapOpts := []unwrap.Option{
+		unwrap.WithSayYes(true),
 		unwrap.WithTempDirectory(wrapWorkdir),
 		unwrap.WithUsePlainHTTP(t.usePlainHTTP),
 		unwrap.WithLogger(cfg.Logger),
-		unwrap.WithAuth(t.username, t.password), unwrap.WithInsecure(t.insecure),
+		unwrap.WithAuth(t.username, t.password),
+		unwrap.WithInsecure(t.insecure),
 		unwrap.WithContainerRegistryAuth(t.containersUsername, t.containersPassword),
 		unwrap.WithSkipImageRelocation(cfg.SkipImages),
 		unwrap.WithSkipPullImages(cfg.SkipImages),
 		unwrap.WithFetchArtifacts(!cfg.SkipArtifacts),
 		unwrap.WithPreserveRepository(false),
 		unwrap.WithPreserveDigest(cfg.PreserveDigest),
-	); err != nil {
+	}
+
+	if cfg.Timeout > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), cfg.Timeout)
+		defer cancel()
+		unwrapOpts = append(unwrapOpts, unwrap.WithContext(ctx))
+	}
+
+	if _, err := unwrap.Container(file, t.getContainersUploadURL(), unwrapOpts...); err != nil {
 		return errors.Trace(err)
 	}
 	return nil

--- a/pkg/client/types/types.go
+++ b/pkg/client/types/types.go
@@ -17,6 +17,22 @@ type ClientOpts struct {
 	cacheDir  string
 	insecure  bool
 	plainHTTP bool
+	timeout   time.Duration
+}
+
+// WithTimeout sets a timeout for network operations
+func WithTimeout(timeout time.Duration) Option {
+	return func(s *ClientOpts) {
+		s.timeout = timeout
+	}
+}
+
+// GetTimeout returns the configured timeout
+func (o *ClientOpts) GetTimeout() time.Duration {
+	if o == nil {
+		return 0
+	}
+	return o.timeout
 }
 
 // Option is an option value used to create a new syncer instance.

--- a/pkg/containersyncer/sync.go
+++ b/pkg/containersyncer/sync.go
@@ -36,6 +36,7 @@ func (s *Syncer) syncContainer(c *types.ContainerImage, tag string, l log.Sectio
 		config.WithContainerPlatforms(s.containerPlatforms),
 		config.WithSkipArtifacts(s.skipArtifacts),
 		config.WithPreserveDigest(s.preserveDigest),
+		config.WithTimeout(s.timeout),
 	)
 	if err != nil {
 		return errors.Annotatef(err, "unable to move container %q with charts-syncer", id)
@@ -48,7 +49,7 @@ func (s *Syncer) syncContainer(c *types.ContainerImage, tag string, l log.Sectio
 		return nil
 	}
 
-	if err := s.cli.dst.UnwrapContainer(wrappedContainerPath, config.WithLogger(l), config.WithWorkDir(workdir), config.WithPreserveDigest(s.preserveDigest)); err != nil {
+	if err := s.cli.dst.UnwrapContainer(wrappedContainerPath, config.WithLogger(l), config.WithWorkDir(workdir), config.WithPreserveDigest(s.preserveDigest), config.WithTimeout(s.timeout)); err != nil {
 		l.Errorf("unable to upload %q container: %+v", id, err)
 		return errors.Trace(err)
 	}

--- a/pkg/containersyncer/syncer.go
+++ b/pkg/containersyncer/syncer.go
@@ -3,6 +3,7 @@ package containersyncer
 
 import (
 	"os"
+	"time"
 
 	apiv1 "github.com/bitnami/charts-syncer/gen/proto/v1"
 	"github.com/bitnami/charts-syncer/pkg/client"
@@ -46,6 +47,9 @@ type Syncer struct {
 	// Storage directory for required artifacts
 	workdir string
 
+	// Timeout for operations
+	timeout time.Duration
+
 	logger log.SectionLogger
 }
 
@@ -84,6 +88,13 @@ func WithSkipArtifacts(skip bool) Option {
 func WithWorkdir(dir string) Option {
 	return func(s *Syncer) {
 		s.workdir = dir
+	}
+}
+
+// WithTimeout configures the syncer to use a specific timeout.
+func WithTimeout(timeout time.Duration) Option {
+	return func(s *Syncer) {
+		s.timeout = timeout
 	}
 }
 
@@ -129,7 +140,7 @@ func New(source *apiv1.Source, target *apiv1.Target, opts ...Option) (*Syncer, e
 	if source.GetContainers() == nil && !sourceIsLocal {
 		return nil, errors.New("missing source.containers config")
 	}
-	srcCli, err := cs.NewContainerClient(source, types.WithCache(s.workdir), types.WithInsecure(s.insecure), types.WithUsePlainHTTP(s.usePlainHTTP))
+	srcCli, err := cs.NewContainerClient(source, types.WithCache(s.workdir), types.WithInsecure(s.insecure), types.WithUsePlainHTTP(s.usePlainHTTP), types.WithTimeout(s.timeout))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -139,7 +150,7 @@ func New(source *apiv1.Source, target *apiv1.Target, opts ...Option) (*Syncer, e
 	if target.GetContainers() == nil && !targetIsLocal {
 		return nil, errors.New("missing target.containers config")
 	}
-	dstCli, err := ct.NewContainerClient(target, types.WithCache(s.workdir), types.WithInsecure(s.insecure), types.WithUsePlainHTTP(s.usePlainHTTP))
+	dstCli, err := ct.NewContainerClient(target, types.WithCache(s.workdir), types.WithInsecure(s.insecure), types.WithUsePlainHTTP(s.usePlainHTTP), types.WithTimeout(s.timeout))
 	if err != nil {
 		return nil, errors.Trace(err)
 	}


### PR DESCRIPTION
## Description

A TAC customer reported timeouts while synchronizing charts due to network restrictions and latency when pulling OCI charts. This PR introduces a `--timeout` flag to give users control over the maximum duration allowed for chart and container image fetch operations.

## Changes

- Added `--timeout` flag (e.g. `--timeout=5m` or `--timeout=300s`) to the `sync` command.
- Set the timeout on global HTTP clients (`utils.DefaultClient`, `utils.InsecureClient`) used for classic Helm chart pulls.
- Integrated the timeout with `go-containerregistry`'s `remote.WithContext` for OCI image and tag operations.
- Propagated the context with the specified timeout down to `distribution-tooling-for-helm` (dt) for chart and container wrap/unwrap operations.

## Testing

- Built the project locally using `go build -o charts-syncer ./cmd` to verify no compilation errors.

ai-assisted=yes